### PR TITLE
ci: format: add workflow that checks formatting of all sub-projects

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,34 @@
+name: format
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '48 20 * * 4'
+
+jobs:
+  format:
+    strategy:
+      fail-fast: false
+      matrix:
+        directory:
+          - "apps/werkbank_werkbank"
+          - "example/example_werkbank"
+          - "packages/werkbank"
+
+    name: dart format
+    runs-on: ubuntu-latest
+    container: ghcr.io/cirruslabs/flutter:stable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.directory }}
+        run: flutter pub get
+
+      - name: Check formatting of project source
+        working-directory: ${{ matrix.directory }}
+        run: dart format --output none --set-exit-if-changed .

--- a/packages/werkbank/lib/src/_internal/src/localizations/src/strings.g.dart
+++ b/packages/werkbank/lib/src/_internal/src/localizations/src/strings.g.dart
@@ -23,52 +23,56 @@ part 'strings_en.g.dart';
 /// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
 /// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
 enum AppLocale with BaseAppLocale<AppLocale, Translations> {
-	en(languageCode: 'en');
+  en(languageCode: 'en');
 
-	const AppLocale({
-		required this.languageCode,
-		this.scriptCode, // ignore: unused_element, unused_element_parameter
-		this.countryCode, // ignore: unused_element, unused_element_parameter
-	});
+  const AppLocale({
+    required this.languageCode,
+    this.scriptCode, // ignore: unused_element, unused_element_parameter
+    this.countryCode, // ignore: unused_element, unused_element_parameter
+  });
 
-	@override final String languageCode;
-	@override final String? scriptCode;
-	@override final String? countryCode;
+  @override
+  final String languageCode;
+  @override
+  final String? scriptCode;
+  @override
+  final String? countryCode;
 
-	@override
-	Future<Translations> build({
-		Map<String, Node>? overrides,
-		PluralResolver? cardinalResolver,
-		PluralResolver? ordinalResolver,
-	}) async {
-		switch (this) {
-			case AppLocale.en:
-				return TranslationsEn(
-					overrides: overrides,
-					cardinalResolver: cardinalResolver,
-					ordinalResolver: ordinalResolver,
-				);
-		}
-	}
+  @override
+  Future<Translations> build({
+    Map<String, Node>? overrides,
+    PluralResolver? cardinalResolver,
+    PluralResolver? ordinalResolver,
+  }) async {
+    switch (this) {
+      case AppLocale.en:
+        return TranslationsEn(
+          overrides: overrides,
+          cardinalResolver: cardinalResolver,
+          ordinalResolver: ordinalResolver,
+        );
+    }
+  }
 
-	@override
-	Translations buildSync({
-		Map<String, Node>? overrides,
-		PluralResolver? cardinalResolver,
-		PluralResolver? ordinalResolver,
-	}) {
-		switch (this) {
-			case AppLocale.en:
-				return TranslationsEn(
-					overrides: overrides,
-					cardinalResolver: cardinalResolver,
-					ordinalResolver: ordinalResolver,
-				);
-		}
-	}
+  @override
+  Translations buildSync({
+    Map<String, Node>? overrides,
+    PluralResolver? cardinalResolver,
+    PluralResolver? ordinalResolver,
+  }) {
+    switch (this) {
+      case AppLocale.en:
+        return TranslationsEn(
+          overrides: overrides,
+          cardinalResolver: cardinalResolver,
+          ordinalResolver: ordinalResolver,
+        );
+    }
+  }
 
-	/// Gets current instance managed by [LocaleSettings].
-	Translations get translations => LocaleSettings.instance.getTranslations(this);
+  /// Gets current instance managed by [LocaleSettings].
+  Translations get translations =>
+      LocaleSettings.instance.getTranslations(this);
 }
 
 /// Method A: Simple
@@ -84,47 +88,88 @@ Translations get t => LocaleSettings.instance.currentTranslations;
 
 /// Manages all translation instances and the current locale
 class LocaleSettings extends BaseLocaleSettings<AppLocale, Translations> {
-	LocaleSettings._() : super(
-		utils: AppLocaleUtils.instance,
-		lazy: true,
-	);
+  LocaleSettings._()
+    : super(
+        utils: AppLocaleUtils.instance,
+        lazy: true,
+      );
 
-	static final instance = LocaleSettings._();
+  static final instance = LocaleSettings._();
 
-	// static aliases (checkout base methods for documentation)
-	static AppLocale get currentLocale => instance.currentLocale;
-	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
-	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
-	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
-	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
-		language: language,
-		locale: locale,
-		cardinalResolver: cardinalResolver,
-		ordinalResolver: ordinalResolver,
-	);
+  // static aliases (checkout base methods for documentation)
+  static AppLocale get currentLocale => instance.currentLocale;
+  static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+  static Future<AppLocale> setLocale(
+    AppLocale locale, {
+    bool? listenToDeviceLocale = false,
+  }) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+  static Future<AppLocale> setLocaleRaw(
+    String rawLocale, {
+    bool? listenToDeviceLocale = false,
+  }) => instance.setLocaleRaw(
+    rawLocale,
+    listenToDeviceLocale: listenToDeviceLocale,
+  );
+  static Future<void> setPluralResolver({
+    String? language,
+    AppLocale? locale,
+    PluralResolver? cardinalResolver,
+    PluralResolver? ordinalResolver,
+  }) => instance.setPluralResolver(
+    language: language,
+    locale: locale,
+    cardinalResolver: cardinalResolver,
+    ordinalResolver: ordinalResolver,
+  );
 
-	// synchronous versions
-	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
-	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
-	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
-		language: language,
-		locale: locale,
-		cardinalResolver: cardinalResolver,
-		ordinalResolver: ordinalResolver,
-	);
+  // synchronous versions
+  static AppLocale setLocaleSync(
+    AppLocale locale, {
+    bool? listenToDeviceLocale = false,
+  }) => instance.setLocaleSync(
+    locale,
+    listenToDeviceLocale: listenToDeviceLocale,
+  );
+  static AppLocale setLocaleRawSync(
+    String rawLocale, {
+    bool? listenToDeviceLocale = false,
+  }) => instance.setLocaleRawSync(
+    rawLocale,
+    listenToDeviceLocale: listenToDeviceLocale,
+  );
+  static void setPluralResolverSync({
+    String? language,
+    AppLocale? locale,
+    PluralResolver? cardinalResolver,
+    PluralResolver? ordinalResolver,
+  }) => instance.setPluralResolverSync(
+    language: language,
+    locale: locale,
+    cardinalResolver: cardinalResolver,
+    ordinalResolver: ordinalResolver,
+  );
 }
 
 /// Provides utility functions without any side effects.
 class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
-	AppLocaleUtils._() : super(
-		baseLocale: AppLocale.en,
-		locales: AppLocale.values,
-	);
+  AppLocaleUtils._()
+    : super(
+        baseLocale: AppLocale.en,
+        locales: AppLocale.values,
+      );
 
-	static final instance = AppLocaleUtils._();
+  static final instance = AppLocaleUtils._();
 
-	// static aliases (checkout base methods for documentation)
-	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
-	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
-	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+  // static aliases (checkout base methods for documentation)
+  static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+  static AppLocale parseLocaleParts({
+    required String languageCode,
+    String? scriptCode,
+    String? countryCode,
+  }) => instance.parseLocaleParts(
+    languageCode: languageCode,
+    scriptCode: scriptCode,
+    countryCode: countryCode,
+  );
+  static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
 }

--- a/packages/werkbank/lib/src/_internal/src/localizations/src/strings_en.g.dart
+++ b/packages/werkbank/lib/src/_internal/src/localizations/src/strings_en.g.dart
@@ -8,968 +8,1182 @@ part of 'strings.g.dart';
 
 // Path: <root>
 typedef TranslationsEn = Translations; // ignore: unused_element
+
 class Translations implements BaseTranslations<AppLocale, Translations> {
-	/// You can call this constructor and build your own translation instance of this locale.
-	/// Constructing via the enum [AppLocale.build] is preferred.
-	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
-		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
-		  $meta = meta ?? TranslationMetadata(
-		    locale: AppLocale.en,
-		    overrides: overrides ?? {},
-		    cardinalResolver: cardinalResolver,
-		    ordinalResolver: ordinalResolver,
-		  ) {
-		$meta.setFlatMapFunction(_flatMapFunction);
-	}
+  /// You can call this constructor and build your own translation instance of this locale.
+  /// Constructing via the enum [AppLocale.build] is preferred.
+  Translations({
+    Map<String, Node>? overrides,
+    PluralResolver? cardinalResolver,
+    PluralResolver? ordinalResolver,
+    TranslationMetadata<AppLocale, Translations>? meta,
+  }) : assert(
+         overrides == null,
+         'Set "translation_overrides: true" in order to enable this feature.',
+       ),
+       $meta =
+           meta ??
+           TranslationMetadata(
+             locale: AppLocale.en,
+             overrides: overrides ?? {},
+             cardinalResolver: cardinalResolver,
+             ordinalResolver: ordinalResolver,
+           ) {
+    $meta.setFlatMapFunction(_flatMapFunction);
+  }
 
-	/// Metadata for the translations of <en>.
-	@override final TranslationMetadata<AppLocale, Translations> $meta;
+  /// Metadata for the translations of <en>.
+  @override
+  final TranslationMetadata<AppLocale, Translations> $meta;
 
-	/// Access flat map
-	dynamic operator[](String key) => $meta.getTranslation(key);
+  /// Access flat map
+  dynamic operator [](String key) => $meta.getTranslation(key);
 
-	late final Translations _root = this; // ignore: unused_field
+  late final Translations _root = this; // ignore: unused_field
 
-	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+  Translations $copyWith({
+    TranslationMetadata<AppLocale, Translations>? meta,
+  }) => Translations(meta: meta ?? this.$meta);
 
-	// Translations
-	late final TranslationsGenericEn generic = TranslationsGenericEn._(_root);
-	late final TranslationsAddonsEn addons = TranslationsAddonsEn._(_root);
-	late final TranslationsAppEn app = TranslationsAppEn._(_root);
-	late final TranslationsNavigationPanelEn navigationPanel = TranslationsNavigationPanelEn._(_root);
-	late final TranslationsConfigurationPanelEn configurationPanel = TranslationsConfigurationPanelEn._(_root);
-	late final TranslationsShortcutsEn shortcuts = TranslationsShortcutsEn._(_root);
-	late final TranslationsOverviewEn overview = TranslationsOverviewEn._(_root);
+  // Translations
+  late final TranslationsGenericEn generic = TranslationsGenericEn._(_root);
+  late final TranslationsAddonsEn addons = TranslationsAddonsEn._(_root);
+  late final TranslationsAppEn app = TranslationsAppEn._(_root);
+  late final TranslationsNavigationPanelEn navigationPanel =
+      TranslationsNavigationPanelEn._(_root);
+  late final TranslationsConfigurationPanelEn configurationPanel =
+      TranslationsConfigurationPanelEn._(_root);
+  late final TranslationsShortcutsEn shortcuts = TranslationsShortcutsEn._(
+    _root,
+  );
+  late final TranslationsOverviewEn overview = TranslationsOverviewEn._(_root);
 }
 
 // Path: generic
 class TranslationsGenericEn {
-	TranslationsGenericEn._(this._root);
+  TranslationsGenericEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsGenericYesNoSwitchEn yesNoSwitch = TranslationsGenericYesNoSwitchEn._(_root);
-	late final TranslationsGenericOnOffSwitchEn onOffSwitch = TranslationsGenericOnOffSwitchEn._(_root);
+  // Translations
+  late final TranslationsGenericYesNoSwitchEn yesNoSwitch =
+      TranslationsGenericYesNoSwitchEn._(_root);
+  late final TranslationsGenericOnOffSwitchEn onOffSwitch =
+      TranslationsGenericOnOffSwitchEn._(_root);
 }
 
 // Path: addons
 class TranslationsAddonsEn {
-	TranslationsAddonsEn._(this._root);
+  TranslationsAddonsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsAccessibilityEn accessibility = TranslationsAddonsAccessibilityEn._(_root);
-	late final TranslationsAddonsBackgroundEn background = TranslationsAddonsBackgroundEn._(_root);
-	late final TranslationsAddonsDebuggingEn debugging = TranslationsAddonsDebuggingEn._(_root);
-	late final TranslationsAddonsHotReloadEffectEn hotReloadEffect = TranslationsAddonsHotReloadEffectEn._(_root);
-	late final TranslationsAddonsKnobsEn knobs = TranslationsAddonsKnobsEn._(_root);
-	late final TranslationsAddonsLocalizationEn localization = TranslationsAddonsLocalizationEn._(_root);
-	late final TranslationsAddonsOrderingEn ordering = TranslationsAddonsOrderingEn._(_root);
-	late final TranslationsAddonsColorPickerEn colorPicker = TranslationsAddonsColorPickerEn._(_root);
-	late final TranslationsAddonsDescriptionEn description = TranslationsAddonsDescriptionEn._(_root);
-	late final TranslationsAddonsPageTransitionEn pageTransition = TranslationsAddonsPageTransitionEn._(_root);
-	late final TranslationsAddonsRecentHistoryEn recentHistory = TranslationsAddonsRecentHistoryEn._(_root);
-	late final TranslationsAddonsAcknowledgedEn acknowledged = TranslationsAddonsAcknowledgedEn._(_root);
-	late final TranslationsAddonsConstraintsEn constraints = TranslationsAddonsConstraintsEn._(_root);
-	late final TranslationsAddonsWerkbankThemeEn werkbank_theme = TranslationsAddonsWerkbankThemeEn._(_root);
-	late final TranslationsAddonsThemingEn theming = TranslationsAddonsThemingEn._(_root);
-	late final TranslationsAddonsZoomEn zoom = TranslationsAddonsZoomEn._(_root);
+  // Translations
+  late final TranslationsAddonsAccessibilityEn accessibility =
+      TranslationsAddonsAccessibilityEn._(_root);
+  late final TranslationsAddonsBackgroundEn background =
+      TranslationsAddonsBackgroundEn._(_root);
+  late final TranslationsAddonsDebuggingEn debugging =
+      TranslationsAddonsDebuggingEn._(_root);
+  late final TranslationsAddonsHotReloadEffectEn hotReloadEffect =
+      TranslationsAddonsHotReloadEffectEn._(_root);
+  late final TranslationsAddonsKnobsEn knobs = TranslationsAddonsKnobsEn._(
+    _root,
+  );
+  late final TranslationsAddonsLocalizationEn localization =
+      TranslationsAddonsLocalizationEn._(_root);
+  late final TranslationsAddonsOrderingEn ordering =
+      TranslationsAddonsOrderingEn._(_root);
+  late final TranslationsAddonsColorPickerEn colorPicker =
+      TranslationsAddonsColorPickerEn._(_root);
+  late final TranslationsAddonsDescriptionEn description =
+      TranslationsAddonsDescriptionEn._(_root);
+  late final TranslationsAddonsPageTransitionEn pageTransition =
+      TranslationsAddonsPageTransitionEn._(_root);
+  late final TranslationsAddonsRecentHistoryEn recentHistory =
+      TranslationsAddonsRecentHistoryEn._(_root);
+  late final TranslationsAddonsAcknowledgedEn acknowledged =
+      TranslationsAddonsAcknowledgedEn._(_root);
+  late final TranslationsAddonsConstraintsEn constraints =
+      TranslationsAddonsConstraintsEn._(_root);
+  late final TranslationsAddonsWerkbankThemeEn werkbank_theme =
+      TranslationsAddonsWerkbankThemeEn._(_root);
+  late final TranslationsAddonsThemingEn theming =
+      TranslationsAddonsThemingEn._(_root);
+  late final TranslationsAddonsZoomEn zoom = TranslationsAddonsZoomEn._(_root);
 }
 
 // Path: app
 class TranslationsAppEn {
-	TranslationsAppEn._(this._root);
+  TranslationsAppEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get duplicatePathErrorTitleMessage => 'Duplicate Paths Found';
-	String duplicatePathErrorContentMessageMarkdown({required Object duplicatePath}) => 'There are multiple folders, components or use cases with the same path:\n${duplicatePath}\n\nRename some nodes such that all the paths are unique.';
+  // Translations
+  String get duplicatePathErrorTitleMessage => 'Duplicate Paths Found';
+  String duplicatePathErrorContentMessageMarkdown({
+    required Object duplicatePath,
+  }) =>
+      'There are multiple folders, components or use cases with the same path:\n${duplicatePath}\n\nRename some nodes such that all the paths are unique.';
 }
 
 // Path: navigationPanel
 class TranslationsNavigationPanelEn {
-	TranslationsNavigationPanelEn._(this._root);
+  TranslationsNavigationPanelEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String lastUpdated({required Object date}) => 'LAST UPDATED ${date}';
-	late final TranslationsNavigationPanelSearchEn search = TranslationsNavigationPanelSearchEn._(_root);
-	String get overview => 'Overview';
+  // Translations
+  String lastUpdated({required Object date}) => 'LAST UPDATED ${date}';
+  late final TranslationsNavigationPanelSearchEn search =
+      TranslationsNavigationPanelSearchEn._(_root);
+  String get overview => 'Overview';
 }
 
 // Path: configurationPanel
 class TranslationsConfigurationPanelEn {
-	TranslationsConfigurationPanelEn._(this._root);
+  TranslationsConfigurationPanelEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String nameCopiedNotificationMessage({required Object name}) => '"${name}" copied to clipboard';
-	String get cantConfigureUseCaseInOverview => 'Cannot configure the use case when overviewing it.';
-	String get noUseCaseSelected => 'No use case selected';
-	late final TranslationsConfigurationPanelTabsEn tabs = TranslationsConfigurationPanelTabsEn._(_root);
+  // Translations
+  String nameCopiedNotificationMessage({required Object name}) =>
+      '"${name}" copied to clipboard';
+  String get cantConfigureUseCaseInOverview =>
+      'Cannot configure the use case when overviewing it.';
+  String get noUseCaseSelected => 'No use case selected';
+  late final TranslationsConfigurationPanelTabsEn tabs =
+      TranslationsConfigurationPanelTabsEn._(_root);
 }
 
 // Path: shortcuts
 class TranslationsShortcutsEn {
-	TranslationsShortcutsEn._(this._root);
+  TranslationsShortcutsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsShortcutsGeneralEn general = TranslationsShortcutsGeneralEn._(_root);
-	late final TranslationsShortcutsNavigationModeEn navigationMode = TranslationsShortcutsNavigationModeEn._(_root);
+  // Translations
+  late final TranslationsShortcutsGeneralEn general =
+      TranslationsShortcutsGeneralEn._(_root);
+  late final TranslationsShortcutsNavigationModeEn navigationMode =
+      TranslationsShortcutsNavigationModeEn._(_root);
 }
 
 // Path: overview
 class TranslationsOverviewEn {
-	TranslationsOverviewEn._(this._root);
+  TranslationsOverviewEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsOverviewOverflowNotificationEn overflow_notification = TranslationsOverviewOverflowNotificationEn._(_root);
+  // Translations
+  late final TranslationsOverviewOverflowNotificationEn overflow_notification =
+      TranslationsOverviewOverflowNotificationEn._(_root);
 }
 
 // Path: generic.yesNoSwitch
 class TranslationsGenericYesNoSwitchEn {
-	TranslationsGenericYesNoSwitchEn._(this._root);
+  TranslationsGenericYesNoSwitchEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get no => 'NO';
-	String get yes => 'YES';
+  // Translations
+  String get no => 'NO';
+  String get yes => 'YES';
 }
 
 // Path: generic.onOffSwitch
 class TranslationsGenericOnOffSwitchEn {
-	TranslationsGenericOnOffSwitchEn._(this._root);
+  TranslationsGenericOnOffSwitchEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get off => 'OFF';
-	String get on => 'ON';
+  // Translations
+  String get off => 'OFF';
+  String get on => 'ON';
 }
 
 // Path: addons.accessibility
 class TranslationsAddonsAccessibilityEn {
-	TranslationsAddonsAccessibilityEn._(this._root);
+  TranslationsAddonsAccessibilityEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Accessibility';
-	late final TranslationsAddonsAccessibilityControlsEn controls = TranslationsAddonsAccessibilityControlsEn._(_root);
-	late final TranslationsAddonsAccessibilityInspectorEn inspector = TranslationsAddonsAccessibilityInspectorEn._(_root);
+  // Translations
+  String get name => 'Accessibility';
+  late final TranslationsAddonsAccessibilityControlsEn controls =
+      TranslationsAddonsAccessibilityControlsEn._(_root);
+  late final TranslationsAddonsAccessibilityInspectorEn inspector =
+      TranslationsAddonsAccessibilityInspectorEn._(_root);
 }
 
 // Path: addons.background
 class TranslationsAddonsBackgroundEn {
-	TranslationsAddonsBackgroundEn._(this._root);
+  TranslationsAddonsBackgroundEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Background';
-	late final TranslationsAddonsBackgroundControlsEn controls = TranslationsAddonsBackgroundControlsEn._(_root);
+  // Translations
+  String get name => 'Background';
+  late final TranslationsAddonsBackgroundControlsEn controls =
+      TranslationsAddonsBackgroundControlsEn._(_root);
 }
 
 // Path: addons.debugging
 class TranslationsAddonsDebuggingEn {
-	TranslationsAddonsDebuggingEn._(this._root);
+  TranslationsAddonsDebuggingEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Debugging (Experimental)';
-	late final TranslationsAddonsDebuggingControlsEn controls = TranslationsAddonsDebuggingControlsEn._(_root);
+  // Translations
+  String get name => 'Debugging (Experimental)';
+  late final TranslationsAddonsDebuggingControlsEn controls =
+      TranslationsAddonsDebuggingControlsEn._(_root);
 }
 
 // Path: addons.hotReloadEffect
 class TranslationsAddonsHotReloadEffectEn {
-	TranslationsAddonsHotReloadEffectEn._(this._root);
+  TranslationsAddonsHotReloadEffectEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Hot Reload Effect';
-	late final TranslationsAddonsHotReloadEffectControlsEn controls = TranslationsAddonsHotReloadEffectControlsEn._(_root);
+  // Translations
+  String get name => 'Hot Reload Effect';
+  late final TranslationsAddonsHotReloadEffectControlsEn controls =
+      TranslationsAddonsHotReloadEffectControlsEn._(_root);
 }
 
 // Path: addons.knobs
 class TranslationsAddonsKnobsEn {
-	TranslationsAddonsKnobsEn._(this._root);
+  TranslationsAddonsKnobsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Knobs';
-	late final TranslationsAddonsKnobsControlsEn controls = TranslationsAddonsKnobsControlsEn._(_root);
-	late final TranslationsAddonsKnobsKnobsEn knobs = TranslationsAddonsKnobsKnobsEn._(_root);
+  // Translations
+  String get name => 'Knobs';
+  late final TranslationsAddonsKnobsControlsEn controls =
+      TranslationsAddonsKnobsControlsEn._(_root);
+  late final TranslationsAddonsKnobsKnobsEn knobs =
+      TranslationsAddonsKnobsKnobsEn._(_root);
 }
 
 // Path: addons.localization
 class TranslationsAddonsLocalizationEn {
-	TranslationsAddonsLocalizationEn._(this._root);
+  TranslationsAddonsLocalizationEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Localization';
-	late final TranslationsAddonsLocalizationControlsEn controls = TranslationsAddonsLocalizationControlsEn._(_root);
+  // Translations
+  String get name => 'Localization';
+  late final TranslationsAddonsLocalizationControlsEn controls =
+      TranslationsAddonsLocalizationControlsEn._(_root);
 }
 
 // Path: addons.ordering
 class TranslationsAddonsOrderingEn {
-	TranslationsAddonsOrderingEn._(this._root);
+  TranslationsAddonsOrderingEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Ordering';
-	late final TranslationsAddonsOrderingControlsEn controls = TranslationsAddonsOrderingControlsEn._(_root);
+  // Translations
+  String get name => 'Ordering';
+  late final TranslationsAddonsOrderingControlsEn controls =
+      TranslationsAddonsOrderingControlsEn._(_root);
 }
 
 // Path: addons.colorPicker
 class TranslationsAddonsColorPickerEn {
-	TranslationsAddonsColorPickerEn._(this._root);
+  TranslationsAddonsColorPickerEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Color Picker';
-	late final TranslationsAddonsColorPickerControlsEn controls = TranslationsAddonsColorPickerControlsEn._(_root);
+  // Translations
+  String get name => 'Color Picker';
+  late final TranslationsAddonsColorPickerControlsEn controls =
+      TranslationsAddonsColorPickerControlsEn._(_root);
 }
 
 // Path: addons.description
 class TranslationsAddonsDescriptionEn {
-	TranslationsAddonsDescriptionEn._(this._root);
+  TranslationsAddonsDescriptionEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String component({required Object name}) => '${name} (Component)';
-	String folder({required Object name}) => '${name} (Folder)';
-	String get sections => '(Sections)';
-	String get tags => 'Tags';
-	String get description => 'Description';
-	String get links => 'External Links';
+  // Translations
+  String component({required Object name}) => '${name} (Component)';
+  String folder({required Object name}) => '${name} (Folder)';
+  String get sections => '(Sections)';
+  String get tags => 'Tags';
+  String get description => 'Description';
+  String get links => 'External Links';
 }
 
 // Path: addons.pageTransition
 class TranslationsAddonsPageTransitionEn {
-	TranslationsAddonsPageTransitionEn._(this._root);
+  TranslationsAddonsPageTransitionEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Page Transition';
+  // Translations
+  String get name => 'Page Transition';
 }
 
 // Path: addons.recentHistory
 class TranslationsAddonsRecentHistoryEn {
-	TranslationsAddonsRecentHistoryEn._(this._root);
+  TranslationsAddonsRecentHistoryEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get homePageComponentTitle => 'Recently Visited';
+  // Translations
+  String get homePageComponentTitle => 'Recently Visited';
 }
 
 // Path: addons.acknowledged
 class TranslationsAddonsAcknowledgedEn {
-	TranslationsAddonsAcknowledgedEn._(this._root);
+  TranslationsAddonsAcknowledgedEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get homePageComponentTitle => 'Recently Added';
+  // Translations
+  String get homePageComponentTitle => 'Recently Added';
 }
 
 // Path: addons.constraints
 class TranslationsAddonsConstraintsEn {
-	TranslationsAddonsConstraintsEn._(this._root);
+  TranslationsAddonsConstraintsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Constraints';
-	late final TranslationsAddonsConstraintsControlsEn controls = TranslationsAddonsConstraintsControlsEn._(_root);
-	late final TranslationsAddonsConstraintsShortcutsEn shortcuts = TranslationsAddonsConstraintsShortcutsEn._(_root);
+  // Translations
+  String get name => 'Constraints';
+  late final TranslationsAddonsConstraintsControlsEn controls =
+      TranslationsAddonsConstraintsControlsEn._(_root);
+  late final TranslationsAddonsConstraintsShortcutsEn shortcuts =
+      TranslationsAddonsConstraintsShortcutsEn._(_root);
 }
 
 // Path: addons.werkbank_theme
 class TranslationsAddonsWerkbankThemeEn {
-	TranslationsAddonsWerkbankThemeEn._(this._root);
+  TranslationsAddonsWerkbankThemeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Werkbank Theme';
-	late final TranslationsAddonsWerkbankThemeControlsEn controls = TranslationsAddonsWerkbankThemeControlsEn._(_root);
+  // Translations
+  String get name => 'Werkbank Theme';
+  late final TranslationsAddonsWerkbankThemeControlsEn controls =
+      TranslationsAddonsWerkbankThemeControlsEn._(_root);
 }
 
 // Path: addons.theming
 class TranslationsAddonsThemingEn {
-	TranslationsAddonsThemingEn._(this._root);
+  TranslationsAddonsThemingEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Theming';
-	late final TranslationsAddonsThemingControlsEn controls = TranslationsAddonsThemingControlsEn._(_root);
+  // Translations
+  String get name => 'Theming';
+  late final TranslationsAddonsThemingControlsEn controls =
+      TranslationsAddonsThemingControlsEn._(_root);
 }
 
 // Path: addons.zoom
 class TranslationsAddonsZoomEn {
-	TranslationsAddonsZoomEn._(this._root);
+  TranslationsAddonsZoomEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Zoom';
-	late final TranslationsAddonsZoomControlsEn controls = TranslationsAddonsZoomControlsEn._(_root);
-	late final TranslationsAddonsZoomShortcutsEn shortcuts = TranslationsAddonsZoomShortcutsEn._(_root);
+  // Translations
+  String get name => 'Zoom';
+  late final TranslationsAddonsZoomControlsEn controls =
+      TranslationsAddonsZoomControlsEn._(_root);
+  late final TranslationsAddonsZoomShortcutsEn shortcuts =
+      TranslationsAddonsZoomShortcutsEn._(_root);
 }
 
 // Path: navigationPanel.search
 class TranslationsNavigationPanelSearchEn {
-	TranslationsNavigationPanelSearchEn._(this._root);
+  TranslationsNavigationPanelSearchEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get hint => 'Search';
+  // Translations
+  String get hint => 'Search';
 }
 
 // Path: configurationPanel.tabs
 class TranslationsConfigurationPanelTabsEn {
-	TranslationsConfigurationPanelTabsEn._(this._root);
+  TranslationsConfigurationPanelTabsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get configure => 'CONFIGURE';
-	String get inspect => 'INSPECT';
-	String get settings => 'SETTINGS';
+  // Translations
+  String get configure => 'CONFIGURE';
+  String get inspect => 'INSPECT';
+  String get settings => 'SETTINGS';
 }
 
 // Path: shortcuts.general
 class TranslationsShortcutsGeneralEn {
-	TranslationsShortcutsGeneralEn._(this._root);
+  TranslationsShortcutsGeneralEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get title => 'General';
-	String get descriptionSearch => 'Open/Focus search';
-	String get descriptionTogglePanel => 'Toggle Panels';
-	String get descriptionHome => 'Home';
+  // Translations
+  String get title => 'General';
+  String get descriptionSearch => 'Open/Focus search';
+  String get descriptionTogglePanel => 'Toggle Panels';
+  String get descriptionHome => 'Home';
 }
 
 // Path: shortcuts.navigationMode
 class TranslationsShortcutsNavigationModeEn {
-	TranslationsShortcutsNavigationModeEn._(this._root);
+  TranslationsShortcutsNavigationModeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get title => 'Navigation Shortcuts';
-	String get descriptionPrevious => 'Navigate to the previous use case';
-	String get keystrokePrevious => 'Arrow Up / Page Up';
-	String get descriptionNext => 'Navigate to the next use case';
-	String get keystrokeNext => 'Arrow Down / Page Down';
+  // Translations
+  String get title => 'Navigation Shortcuts';
+  String get descriptionPrevious => 'Navigate to the previous use case';
+  String get keystrokePrevious => 'Arrow Up / Page Up';
+  String get descriptionNext => 'Navigate to the next use case';
+  String get keystrokeNext => 'Arrow Down / Page Down';
 }
 
 // Path: overview.overflow_notification
 class TranslationsOverviewOverflowNotificationEn {
-	TranslationsOverviewOverflowNotificationEn._(this._root);
+  TranslationsOverviewOverflowNotificationEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get title => 'Fix Overflows in the Overview';
-	String get contentMarkdown => 'You seem to be having issues with overflows in the overview.\nThis may be because the thumbnails provide to little space for the widget being displayed.\n\nThere are several ways in which you can control the presentation of the thumbnail,\nincluding setting the scale, which can effectively give the widget more space.\n\nExplore these methods by typing `c.overview.` in your use case\nand autocompleting the methods that are available.\n\nTake a look at the "Overview" topic in the API docs, which explains these methods in detail.';
-	String get contentWithConstraintsAddonMarkdown => '${_root.overview.overflow_notification.contentMarkdown}\n\nAdditionally, since you are using the `ConstraintsAddon`, note that the lower bounds given to\n`c.constraints.supported(...)` also set the minimum size that is used for the thumbnail\nunless `limitOverviewSize` is set to `false`.\nAlso by using for example `c.constraints.overview(...)` you can set the view constraints\nthat are used in the overview. If this is not set, the view constraints used in the\noverview falls back to the initial view constraints that are also used when\nviewing the use case.';
+  // Translations
+  String get title => 'Fix Overflows in the Overview';
+  String get contentMarkdown =>
+      'You seem to be having issues with overflows in the overview.\nThis may be because the thumbnails provide to little space for the widget being displayed.\n\nThere are several ways in which you can control the presentation of the thumbnail,\nincluding setting the scale, which can effectively give the widget more space.\n\nExplore these methods by typing `c.overview.` in your use case\nand autocompleting the methods that are available.\n\nTake a look at the "Overview" topic in the API docs, which explains these methods in detail.';
+  String get contentWithConstraintsAddonMarkdown =>
+      '${_root.overview.overflow_notification.contentMarkdown}\n\nAdditionally, since you are using the `ConstraintsAddon`, note that the lower bounds given to\n`c.constraints.supported(...)` also set the minimum size that is used for the thumbnail\nunless `limitOverviewSize` is set to `false`.\nAlso by using for example `c.constraints.overview(...)` you can set the view constraints\nthat are used in the overview. If this is not set, the view constraints used in the\noverview falls back to the initial view constraints that are also used when\nviewing the use case.';
 }
 
 // Path: addons.accessibility.controls
 class TranslationsAddonsAccessibilityControlsEn {
-	TranslationsAddonsAccessibilityControlsEn._(this._root);
+  TranslationsAddonsAccessibilityControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get textScaleFactor => 'Text Scale Factor';
-	String get boldText => 'Bold Text';
-	late final TranslationsAddonsAccessibilityControlsSemanticsModeEn semanticsMode = TranslationsAddonsAccessibilityControlsSemanticsModeEn._(_root);
-	String get semanticsTree => 'Semantics Tree';
-	String get activeSemanticsNode => 'Active Semantics Node';
-	late final TranslationsAddonsAccessibilityControlsColorModeEn colorMode = TranslationsAddonsAccessibilityControlsColorModeEn._(_root);
+  // Translations
+  String get textScaleFactor => 'Text Scale Factor';
+  String get boldText => 'Bold Text';
+  late final TranslationsAddonsAccessibilityControlsSemanticsModeEn
+  semanticsMode = TranslationsAddonsAccessibilityControlsSemanticsModeEn._(
+    _root,
+  );
+  String get semanticsTree => 'Semantics Tree';
+  String get activeSemanticsNode => 'Active Semantics Node';
+  late final TranslationsAddonsAccessibilityControlsColorModeEn colorMode =
+      TranslationsAddonsAccessibilityControlsColorModeEn._(_root);
 }
 
 // Path: addons.accessibility.inspector
 class TranslationsAddonsAccessibilityInspectorEn {
-	TranslationsAddonsAccessibilityInspectorEn._(this._root);
+  TranslationsAddonsAccessibilityInspectorEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Semantics Inspector';
+  // Translations
+  String get name => 'Semantics Inspector';
 }
 
 // Path: addons.background.controls
 class TranslationsAddonsBackgroundControlsEn {
-	TranslationsAddonsBackgroundControlsEn._(this._root);
+  TranslationsAddonsBackgroundControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsBackgroundControlsBackgroundEn background = TranslationsAddonsBackgroundControlsBackgroundEn._(_root);
+  // Translations
+  late final TranslationsAddonsBackgroundControlsBackgroundEn background =
+      TranslationsAddonsBackgroundControlsBackgroundEn._(_root);
 }
 
 // Path: addons.debugging.controls
 class TranslationsAddonsDebuggingControlsEn {
-	TranslationsAddonsDebuggingControlsEn._(this._root);
+  TranslationsAddonsDebuggingControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get performanceOverlay => 'Performance Overlay';
-	String get paintBaselines => 'Paint Baselines';
-	String get paintSize => 'Paint Size';
-	String get repaintTextRainbow => 'Repaint Text Rainbow';
-	String get repaintRainbow => 'Repaint Rainbow';
-	String get timeDilation => 'Time Dilation';
+  // Translations
+  String get performanceOverlay => 'Performance Overlay';
+  String get paintBaselines => 'Paint Baselines';
+  String get paintSize => 'Paint Size';
+  String get repaintTextRainbow => 'Repaint Text Rainbow';
+  String get repaintRainbow => 'Repaint Rainbow';
+  String get timeDilation => 'Time Dilation';
 }
 
 // Path: addons.hotReloadEffect.controls
 class TranslationsAddonsHotReloadEffectControlsEn {
-	TranslationsAddonsHotReloadEffectControlsEn._(this._root);
+  TranslationsAddonsHotReloadEffectControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get hotReloadEffect => 'Hot Reload Effect';
+  // Translations
+  String get hotReloadEffect => 'Hot Reload Effect';
 }
 
 // Path: addons.knobs.controls
 class TranslationsAddonsKnobsControlsEn {
-	TranslationsAddonsKnobsControlsEn._(this._root);
+  TranslationsAddonsKnobsControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsKnobsControlsPresetEn preset = TranslationsAddonsKnobsControlsPresetEn._(_root);
+  // Translations
+  late final TranslationsAddonsKnobsControlsPresetEn preset =
+      TranslationsAddonsKnobsControlsPresetEn._(_root);
 }
 
 // Path: addons.knobs.knobs
 class TranslationsAddonsKnobsKnobsEn {
-	TranslationsAddonsKnobsKnobsEn._(this._root);
+  TranslationsAddonsKnobsKnobsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsKnobsKnobsBooleanEn boolean = TranslationsAddonsKnobsKnobsBooleanEn._(_root);
-	late final TranslationsAddonsKnobsKnobsIntervalEn interval = TranslationsAddonsKnobsKnobsIntervalEn._(_root);
-	late final TranslationsAddonsKnobsKnobsFocusnodeEn focusnode = TranslationsAddonsKnobsKnobsFocusnodeEn._(_root);
+  // Translations
+  late final TranslationsAddonsKnobsKnobsBooleanEn boolean =
+      TranslationsAddonsKnobsKnobsBooleanEn._(_root);
+  late final TranslationsAddonsKnobsKnobsIntervalEn interval =
+      TranslationsAddonsKnobsKnobsIntervalEn._(_root);
+  late final TranslationsAddonsKnobsKnobsFocusnodeEn focusnode =
+      TranslationsAddonsKnobsKnobsFocusnodeEn._(_root);
 }
 
 // Path: addons.localization.controls
 class TranslationsAddonsLocalizationControlsEn {
-	TranslationsAddonsLocalizationControlsEn._(this._root);
+  TranslationsAddonsLocalizationControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get locale => 'Locale';
+  // Translations
+  String get locale => 'Locale';
 }
 
 // Path: addons.ordering.controls
 class TranslationsAddonsOrderingControlsEn {
-	TranslationsAddonsOrderingControlsEn._(this._root);
+  TranslationsAddonsOrderingControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsOrderingControlsOrderEn order = TranslationsAddonsOrderingControlsOrderEn._(_root);
+  // Translations
+  late final TranslationsAddonsOrderingControlsOrderEn order =
+      TranslationsAddonsOrderingControlsOrderEn._(_root);
 }
 
 // Path: addons.colorPicker.controls
 class TranslationsAddonsColorPickerControlsEn {
-	TranslationsAddonsColorPickerControlsEn._(this._root);
+  TranslationsAddonsColorPickerControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsColorPickerControlsColorPickerEn colorPicker = TranslationsAddonsColorPickerControlsColorPickerEn._(_root);
+  // Translations
+  late final TranslationsAddonsColorPickerControlsColorPickerEn colorPicker =
+      TranslationsAddonsColorPickerControlsColorPickerEn._(_root);
 }
 
 // Path: addons.constraints.controls
 class TranslationsAddonsConstraintsControlsEn {
-	TranslationsAddonsConstraintsControlsEn._(this._root);
+  TranslationsAddonsConstraintsControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsConstraintsControlsPresetEn preset = TranslationsAddonsConstraintsControlsPresetEn._(_root);
-	late final TranslationsAddonsConstraintsControlsConstraintsEn constraints = TranslationsAddonsConstraintsControlsConstraintsEn._(_root);
-	late final TranslationsAddonsConstraintsControlsSizeEn size = TranslationsAddonsConstraintsControlsSizeEn._(_root);
+  // Translations
+  late final TranslationsAddonsConstraintsControlsPresetEn preset =
+      TranslationsAddonsConstraintsControlsPresetEn._(_root);
+  late final TranslationsAddonsConstraintsControlsConstraintsEn constraints =
+      TranslationsAddonsConstraintsControlsConstraintsEn._(_root);
+  late final TranslationsAddonsConstraintsControlsSizeEn size =
+      TranslationsAddonsConstraintsControlsSizeEn._(_root);
 }
 
 // Path: addons.constraints.shortcuts
 class TranslationsAddonsConstraintsShortcutsEn {
-	TranslationsAddonsConstraintsShortcutsEn._(this._root);
+  TranslationsAddonsConstraintsShortcutsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get title => 'Constraints Mode Change Shortcuts';
-	String get subTitle => 'Use the ruler to size one axis to tight constraints';
-	String get descriptionResize => 'Resize both axes to tight constraints';
-	String get descriptionMinSize => 'Apply minimum size constraints';
-	String get descriptionMaxSize => 'Apply maximum size constraints';
+  // Translations
+  String get title => 'Constraints Mode Change Shortcuts';
+  String get subTitle => 'Use the ruler to size one axis to tight constraints';
+  String get descriptionResize => 'Resize both axes to tight constraints';
+  String get descriptionMinSize => 'Apply minimum size constraints';
+  String get descriptionMaxSize => 'Apply maximum size constraints';
 }
 
 // Path: addons.werkbank_theme.controls
 class TranslationsAddonsWerkbankThemeControlsEn {
-	TranslationsAddonsWerkbankThemeControlsEn._(this._root);
+  TranslationsAddonsWerkbankThemeControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get theme => 'Theme';
+  // Translations
+  String get theme => 'Theme';
 }
 
 // Path: addons.theming.controls
 class TranslationsAddonsThemingControlsEn {
-	TranslationsAddonsThemingControlsEn._(this._root);
+  TranslationsAddonsThemingControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get theme => 'Theme';
+  // Translations
+  String get theme => 'Theme';
 }
 
 // Path: addons.zoom.controls
 class TranslationsAddonsZoomControlsEn {
-	TranslationsAddonsZoomControlsEn._(this._root);
+  TranslationsAddonsZoomControlsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get enabled => 'Enabled';
-	String get magnification => 'Magnification';
+  // Translations
+  String get enabled => 'Enabled';
+  String get magnification => 'Magnification';
 }
 
 // Path: addons.zoom.shortcuts
 class TranslationsAddonsZoomShortcutsEn {
-	TranslationsAddonsZoomShortcutsEn._(this._root);
+  TranslationsAddonsZoomShortcutsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get title => 'Zoom/Pan Shortcuts';
-	String get descriptionZoom => 'Zoom in and out';
-	String get keystrokeZoom => 'Mouse Wheel';
-	String get descriptionReset => 'Reset zoom';
-	String get descriptionZoomIn => 'Zoom in';
-	String get descriptionZoomOut => 'Zoom out';
-	String get descriptionPan => 'Pan the view';
-	String get keystrokePan => 'Left or Middle Mouse Button Drag';
-	String get descriptionZoomPan => 'Zoom/Pan the view';
-	String get keystrokeZoomPan => 'Zoom/Pan gestures on Trackpad';
+  // Translations
+  String get title => 'Zoom/Pan Shortcuts';
+  String get descriptionZoom => 'Zoom in and out';
+  String get keystrokeZoom => 'Mouse Wheel';
+  String get descriptionReset => 'Reset zoom';
+  String get descriptionZoomIn => 'Zoom in';
+  String get descriptionZoomOut => 'Zoom out';
+  String get descriptionPan => 'Pan the view';
+  String get keystrokePan => 'Left or Middle Mouse Button Drag';
+  String get descriptionZoomPan => 'Zoom/Pan the view';
+  String get keystrokeZoomPan => 'Zoom/Pan gestures on Trackpad';
 }
 
 // Path: addons.accessibility.controls.semanticsMode
 class TranslationsAddonsAccessibilityControlsSemanticsModeEn {
-	TranslationsAddonsAccessibilityControlsSemanticsModeEn._(this._root);
+  TranslationsAddonsAccessibilityControlsSemanticsModeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Semantics Mode';
-	late final TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn values = TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn._(_root);
+  // Translations
+  String get name => 'Semantics Mode';
+  late final TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn
+  values = TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn._(
+    _root,
+  );
 }
 
 // Path: addons.accessibility.controls.colorMode
 class TranslationsAddonsAccessibilityControlsColorModeEn {
-	TranslationsAddonsAccessibilityControlsColorModeEn._(this._root);
+  TranslationsAddonsAccessibilityControlsColorModeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Simulated Color Blindness';
-	late final TranslationsAddonsAccessibilityControlsColorModeValuesEn values = TranslationsAddonsAccessibilityControlsColorModeValuesEn._(_root);
+  // Translations
+  String get name => 'Simulated Color Blindness';
+  late final TranslationsAddonsAccessibilityControlsColorModeValuesEn values =
+      TranslationsAddonsAccessibilityControlsColorModeValuesEn._(_root);
 }
 
 // Path: addons.background.controls.background
 class TranslationsAddonsBackgroundControlsBackgroundEn {
-	TranslationsAddonsBackgroundControlsBackgroundEn._(this._root);
+  TranslationsAddonsBackgroundControlsBackgroundEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get label => 'Background';
-	late final TranslationsAddonsBackgroundControlsBackgroundValuesEn values = TranslationsAddonsBackgroundControlsBackgroundValuesEn._(_root);
+  // Translations
+  String get label => 'Background';
+  late final TranslationsAddonsBackgroundControlsBackgroundValuesEn values =
+      TranslationsAddonsBackgroundControlsBackgroundValuesEn._(_root);
 }
 
 // Path: addons.knobs.controls.preset
 class TranslationsAddonsKnobsControlsPresetEn {
-	TranslationsAddonsKnobsControlsPresetEn._(this._root);
+  TranslationsAddonsKnobsControlsPresetEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Preset';
-	late final TranslationsAddonsKnobsControlsPresetValuesEn values = TranslationsAddonsKnobsControlsPresetValuesEn._(_root);
+  // Translations
+  String get name => 'Preset';
+  late final TranslationsAddonsKnobsControlsPresetValuesEn values =
+      TranslationsAddonsKnobsControlsPresetValuesEn._(_root);
 }
 
 // Path: addons.knobs.knobs.boolean
 class TranslationsAddonsKnobsKnobsBooleanEn {
-	TranslationsAddonsKnobsKnobsBooleanEn._(this._root);
+  TranslationsAddonsKnobsKnobsBooleanEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	late final TranslationsAddonsKnobsKnobsBooleanValuesEn values = TranslationsAddonsKnobsKnobsBooleanValuesEn._(_root);
+  // Translations
+  late final TranslationsAddonsKnobsKnobsBooleanValuesEn values =
+      TranslationsAddonsKnobsKnobsBooleanValuesEn._(_root);
 }
 
 // Path: addons.knobs.knobs.interval
 class TranslationsAddonsKnobsKnobsIntervalEn {
-	TranslationsAddonsKnobsKnobsIntervalEn._(this._root);
+  TranslationsAddonsKnobsKnobsIntervalEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get begin => 'Begin';
-	String get end => 'End';
+  // Translations
+  String get begin => 'Begin';
+  String get end => 'End';
 }
 
 // Path: addons.knobs.knobs.focusnode
 class TranslationsAddonsKnobsKnobsFocusnodeEn {
-	TranslationsAddonsKnobsKnobsFocusnodeEn._(this._root);
+  TranslationsAddonsKnobsKnobsFocusnodeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get unfocused => 'Unfocused';
-	String get focused => 'Focused';
+  // Translations
+  String get unfocused => 'Unfocused';
+  String get focused => 'Focused';
 }
 
 // Path: addons.ordering.controls.order
 class TranslationsAddonsOrderingControlsOrderEn {
-	TranslationsAddonsOrderingControlsOrderEn._(this._root);
+  TranslationsAddonsOrderingControlsOrderEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Order';
-	late final TranslationsAddonsOrderingControlsOrderValuesEn values = TranslationsAddonsOrderingControlsOrderValuesEn._(_root);
+  // Translations
+  String get name => 'Order';
+  late final TranslationsAddonsOrderingControlsOrderValuesEn values =
+      TranslationsAddonsOrderingControlsOrderValuesEn._(_root);
 }
 
 // Path: addons.colorPicker.controls.colorPicker
 class TranslationsAddonsColorPickerControlsColorPickerEn {
-	TranslationsAddonsColorPickerControlsColorPickerEn._(this._root);
+  TranslationsAddonsColorPickerControlsColorPickerEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Color Picker';
-	late final TranslationsAddonsColorPickerControlsColorPickerValuesEn values = TranslationsAddonsColorPickerControlsColorPickerValuesEn._(_root);
+  // Translations
+  String get name => 'Color Picker';
+  late final TranslationsAddonsColorPickerControlsColorPickerValuesEn values =
+      TranslationsAddonsColorPickerControlsColorPickerValuesEn._(_root);
 }
 
 // Path: addons.constraints.controls.preset
 class TranslationsAddonsConstraintsControlsPresetEn {
-	TranslationsAddonsConstraintsControlsPresetEn._(this._root);
+  TranslationsAddonsConstraintsControlsPresetEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Preset';
-	late final TranslationsAddonsConstraintsControlsPresetValuesEn values = TranslationsAddonsConstraintsControlsPresetValuesEn._(_root);
+  // Translations
+  String get name => 'Preset';
+  late final TranslationsAddonsConstraintsControlsPresetValuesEn values =
+      TranslationsAddonsConstraintsControlsPresetValuesEn._(_root);
 }
 
 // Path: addons.constraints.controls.constraints
 class TranslationsAddonsConstraintsControlsConstraintsEn {
-	TranslationsAddonsConstraintsControlsConstraintsEn._(this._root);
+  TranslationsAddonsConstraintsControlsConstraintsEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Constraints';
-	late final TranslationsAddonsConstraintsControlsConstraintsValuesEn values = TranslationsAddonsConstraintsControlsConstraintsValuesEn._(_root);
+  // Translations
+  String get name => 'Constraints';
+  late final TranslationsAddonsConstraintsControlsConstraintsValuesEn values =
+      TranslationsAddonsConstraintsControlsConstraintsValuesEn._(_root);
 }
 
 // Path: addons.constraints.controls.size
 class TranslationsAddonsConstraintsControlsSizeEn {
-	TranslationsAddonsConstraintsControlsSizeEn._(this._root);
+  TranslationsAddonsConstraintsControlsSizeEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get name => 'Size';
-	late final TranslationsAddonsConstraintsControlsSizeValuesEn values = TranslationsAddonsConstraintsControlsSizeValuesEn._(_root);
+  // Translations
+  String get name => 'Size';
+  late final TranslationsAddonsConstraintsControlsSizeValuesEn values =
+      TranslationsAddonsConstraintsControlsSizeValuesEn._(_root);
 }
 
 // Path: addons.accessibility.controls.semanticsMode.values
 class TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn {
-	TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn._(this._root);
+  TranslationsAddonsAccessibilityControlsSemanticsModeValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get none => 'None';
-	String get overlay => 'Overlay';
-	String get inspection => 'Inspection';
+  // Translations
+  String get none => 'None';
+  String get overlay => 'Overlay';
+  String get inspection => 'Inspection';
 }
 
 // Path: addons.accessibility.controls.colorMode.values
 class TranslationsAddonsAccessibilityControlsColorModeValuesEn {
-	TranslationsAddonsAccessibilityControlsColorModeValuesEn._(this._root);
+  TranslationsAddonsAccessibilityControlsColorModeValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get none => 'None';
-	String get protanopia => 'Protanopia (red blindness)';
-	String get deuteranopia => 'Deuteranopia (green blindness)';
-	String get tritanopia => 'Tritanopia (blue blindness)';
-	String get protanomaly => 'Protanomaly (red weakness)';
-	String get deuteranomaly => 'Deuteranomaly (green weakness)';
-	String get tritanomaly => 'Tritanomaly (blue weakness)';
-	String get inverted => 'Inverted';
-	String get grayscale => 'Grayscale';
+  // Translations
+  String get none => 'None';
+  String get protanopia => 'Protanopia (red blindness)';
+  String get deuteranopia => 'Deuteranopia (green blindness)';
+  String get tritanopia => 'Tritanopia (blue blindness)';
+  String get protanomaly => 'Protanomaly (red weakness)';
+  String get deuteranomaly => 'Deuteranomaly (green weakness)';
+  String get tritanomaly => 'Tritanomaly (blue weakness)';
+  String get inverted => 'Inverted';
+  String get grayscale => 'Grayscale';
 }
 
 // Path: addons.background.controls.background.values
 class TranslationsAddonsBackgroundControlsBackgroundValuesEn {
-	TranslationsAddonsBackgroundControlsBackgroundValuesEn._(this._root);
+  TranslationsAddonsBackgroundControlsBackgroundValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get useCaseDefault => 'Use Case Default';
+  // Translations
+  String get useCaseDefault => 'Use Case Default';
 }
 
 // Path: addons.knobs.controls.preset.values
 class TranslationsAddonsKnobsControlsPresetValuesEn {
-	TranslationsAddonsKnobsControlsPresetValuesEn._(this._root);
+  TranslationsAddonsKnobsControlsPresetValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get initial => 'Initial';
-	String get unknown => '-';
+  // Translations
+  String get initial => 'Initial';
+  String get unknown => '-';
 }
 
 // Path: addons.knobs.knobs.boolean.values
 class TranslationsAddonsKnobsKnobsBooleanValuesEn {
-	TranslationsAddonsKnobsKnobsBooleanValuesEn._(this._root);
+  TranslationsAddonsKnobsKnobsBooleanValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get falseLabel => 'FALSE';
-	String get trueLabel => 'TRUE';
+  // Translations
+  String get falseLabel => 'FALSE';
+  String get trueLabel => 'TRUE';
 }
 
 // Path: addons.ordering.controls.order.values
 class TranslationsAddonsOrderingControlsOrderValuesEn {
-	TranslationsAddonsOrderingControlsOrderValuesEn._(this._root);
+  TranslationsAddonsOrderingControlsOrderValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get code => 'Code';
-	String get alphabetical => 'Alphabetical';
+  // Translations
+  String get code => 'Code';
+  String get alphabetical => 'Alphabetical';
 }
 
 // Path: addons.colorPicker.controls.colorPicker.values
 class TranslationsAddonsColorPickerControlsColorPickerValuesEn {
-	TranslationsAddonsColorPickerControlsColorPickerValuesEn._(this._root);
+  TranslationsAddonsColorPickerControlsColorPickerValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get color => 'Color';
-	String get noSelectedColor => 'No color selected';
-	String get colorCopied => 'Hex Code copied to clipboard';
-	String get pickedColor => 'Picked Color';
+  // Translations
+  String get color => 'Color';
+  String get noSelectedColor => 'No color selected';
+  String get colorCopied => 'Hex Code copied to clipboard';
+  String get pickedColor => 'Picked Color';
 }
 
 // Path: addons.constraints.controls.preset.values
 class TranslationsAddonsConstraintsControlsPresetValuesEn {
-	TranslationsAddonsConstraintsControlsPresetValuesEn._(this._root);
+  TranslationsAddonsConstraintsControlsPresetValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get initial => 'Initial';
-	String get unknown => '-';
+  // Translations
+  String get initial => 'Initial';
+  String get unknown => '-';
 }
 
 // Path: addons.constraints.controls.constraints.values
 class TranslationsAddonsConstraintsControlsConstraintsValuesEn {
-	TranslationsAddonsConstraintsControlsConstraintsValuesEn._(this._root);
+  TranslationsAddonsConstraintsControlsConstraintsValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get minWidth => 'Min Width';
-	String get maxWidth => 'Max Width';
-	String get minHeight => 'Min Height';
-	String get maxHeight => 'Max Height';
+  // Translations
+  String get minWidth => 'Min Width';
+  String get maxWidth => 'Max Width';
+  String get minHeight => 'Min Height';
+  String get maxHeight => 'Max Height';
 }
 
 // Path: addons.constraints.controls.size.values
 class TranslationsAddonsConstraintsControlsSizeValuesEn {
-	TranslationsAddonsConstraintsControlsSizeValuesEn._(this._root);
+  TranslationsAddonsConstraintsControlsSizeValuesEn._(this._root);
 
-	final Translations _root; // ignore: unused_field
+  final Translations _root; // ignore: unused_field
 
-	// Translations
-	String get width => 'Width';
-	String get height => 'Height';
+  // Translations
+  String get width => 'Width';
+  String get height => 'Height';
 }
 
 /// Flat map(s) containing all translations.
 /// Only for edge cases! For simple maps, use the map function of this library.
 extension on Translations {
-	dynamic _flatMapFunction(String path) {
-		switch (path) {
-			case 'generic.yesNoSwitch.no': return 'NO';
-			case 'generic.yesNoSwitch.yes': return 'YES';
-			case 'generic.onOffSwitch.off': return 'OFF';
-			case 'generic.onOffSwitch.on': return 'ON';
-			case 'addons.accessibility.name': return 'Accessibility';
-			case 'addons.accessibility.controls.textScaleFactor': return 'Text Scale Factor';
-			case 'addons.accessibility.controls.boldText': return 'Bold Text';
-			case 'addons.accessibility.controls.semanticsMode.name': return 'Semantics Mode';
-			case 'addons.accessibility.controls.semanticsMode.values.none': return 'None';
-			case 'addons.accessibility.controls.semanticsMode.values.overlay': return 'Overlay';
-			case 'addons.accessibility.controls.semanticsMode.values.inspection': return 'Inspection';
-			case 'addons.accessibility.controls.semanticsTree': return 'Semantics Tree';
-			case 'addons.accessibility.controls.activeSemanticsNode': return 'Active Semantics Node';
-			case 'addons.accessibility.controls.colorMode.name': return 'Simulated Color Blindness';
-			case 'addons.accessibility.controls.colorMode.values.none': return 'None';
-			case 'addons.accessibility.controls.colorMode.values.protanopia': return 'Protanopia (red blindness)';
-			case 'addons.accessibility.controls.colorMode.values.deuteranopia': return 'Deuteranopia (green blindness)';
-			case 'addons.accessibility.controls.colorMode.values.tritanopia': return 'Tritanopia (blue blindness)';
-			case 'addons.accessibility.controls.colorMode.values.protanomaly': return 'Protanomaly (red weakness)';
-			case 'addons.accessibility.controls.colorMode.values.deuteranomaly': return 'Deuteranomaly (green weakness)';
-			case 'addons.accessibility.controls.colorMode.values.tritanomaly': return 'Tritanomaly (blue weakness)';
-			case 'addons.accessibility.controls.colorMode.values.inverted': return 'Inverted';
-			case 'addons.accessibility.controls.colorMode.values.grayscale': return 'Grayscale';
-			case 'addons.accessibility.inspector.name': return 'Semantics Inspector';
-			case 'addons.background.name': return 'Background';
-			case 'addons.background.controls.background.label': return 'Background';
-			case 'addons.background.controls.background.values.useCaseDefault': return 'Use Case Default';
-			case 'addons.debugging.name': return 'Debugging (Experimental)';
-			case 'addons.debugging.controls.performanceOverlay': return 'Performance Overlay';
-			case 'addons.debugging.controls.paintBaselines': return 'Paint Baselines';
-			case 'addons.debugging.controls.paintSize': return 'Paint Size';
-			case 'addons.debugging.controls.repaintTextRainbow': return 'Repaint Text Rainbow';
-			case 'addons.debugging.controls.repaintRainbow': return 'Repaint Rainbow';
-			case 'addons.debugging.controls.timeDilation': return 'Time Dilation';
-			case 'addons.hotReloadEffect.name': return 'Hot Reload Effect';
-			case 'addons.hotReloadEffect.controls.hotReloadEffect': return 'Hot Reload Effect';
-			case 'addons.knobs.name': return 'Knobs';
-			case 'addons.knobs.controls.preset.name': return 'Preset';
-			case 'addons.knobs.controls.preset.values.initial': return 'Initial';
-			case 'addons.knobs.controls.preset.values.unknown': return '-';
-			case 'addons.knobs.knobs.boolean.values.falseLabel': return 'FALSE';
-			case 'addons.knobs.knobs.boolean.values.trueLabel': return 'TRUE';
-			case 'addons.knobs.knobs.interval.begin': return 'Begin';
-			case 'addons.knobs.knobs.interval.end': return 'End';
-			case 'addons.knobs.knobs.focusnode.unfocused': return 'Unfocused';
-			case 'addons.knobs.knobs.focusnode.focused': return 'Focused';
-			case 'addons.localization.name': return 'Localization';
-			case 'addons.localization.controls.locale': return 'Locale';
-			case 'addons.ordering.name': return 'Ordering';
-			case 'addons.ordering.controls.order.name': return 'Order';
-			case 'addons.ordering.controls.order.values.code': return 'Code';
-			case 'addons.ordering.controls.order.values.alphabetical': return 'Alphabetical';
-			case 'addons.colorPicker.name': return 'Color Picker';
-			case 'addons.colorPicker.controls.colorPicker.name': return 'Color Picker';
-			case 'addons.colorPicker.controls.colorPicker.values.color': return 'Color';
-			case 'addons.colorPicker.controls.colorPicker.values.noSelectedColor': return 'No color selected';
-			case 'addons.colorPicker.controls.colorPicker.values.colorCopied': return 'Hex Code copied to clipboard';
-			case 'addons.colorPicker.controls.colorPicker.values.pickedColor': return 'Picked Color';
-			case 'addons.description.component': return ({required Object name}) => '${name} (Component)';
-			case 'addons.description.folder': return ({required Object name}) => '${name} (Folder)';
-			case 'addons.description.sections': return '(Sections)';
-			case 'addons.description.tags': return 'Tags';
-			case 'addons.description.description': return 'Description';
-			case 'addons.description.links': return 'External Links';
-			case 'addons.pageTransition.name': return 'Page Transition';
-			case 'addons.recentHistory.homePageComponentTitle': return 'Recently Visited';
-			case 'addons.acknowledged.homePageComponentTitle': return 'Recently Added';
-			case 'addons.constraints.name': return 'Constraints';
-			case 'addons.constraints.controls.preset.name': return 'Preset';
-			case 'addons.constraints.controls.preset.values.initial': return 'Initial';
-			case 'addons.constraints.controls.preset.values.unknown': return '-';
-			case 'addons.constraints.controls.constraints.name': return 'Constraints';
-			case 'addons.constraints.controls.constraints.values.minWidth': return 'Min Width';
-			case 'addons.constraints.controls.constraints.values.maxWidth': return 'Max Width';
-			case 'addons.constraints.controls.constraints.values.minHeight': return 'Min Height';
-			case 'addons.constraints.controls.constraints.values.maxHeight': return 'Max Height';
-			case 'addons.constraints.controls.size.name': return 'Size';
-			case 'addons.constraints.controls.size.values.width': return 'Width';
-			case 'addons.constraints.controls.size.values.height': return 'Height';
-			case 'addons.constraints.shortcuts.title': return 'Constraints Mode Change Shortcuts';
-			case 'addons.constraints.shortcuts.subTitle': return 'Use the ruler to size one axis to tight constraints';
-			case 'addons.constraints.shortcuts.descriptionResize': return 'Resize both axes to tight constraints';
-			case 'addons.constraints.shortcuts.descriptionMinSize': return 'Apply minimum size constraints';
-			case 'addons.constraints.shortcuts.descriptionMaxSize': return 'Apply maximum size constraints';
-			case 'addons.werkbank_theme.name': return 'Werkbank Theme';
-			case 'addons.werkbank_theme.controls.theme': return 'Theme';
-			case 'addons.theming.name': return 'Theming';
-			case 'addons.theming.controls.theme': return 'Theme';
-			case 'addons.zoom.name': return 'Zoom';
-			case 'addons.zoom.controls.enabled': return 'Enabled';
-			case 'addons.zoom.controls.magnification': return 'Magnification';
-			case 'addons.zoom.shortcuts.title': return 'Zoom/Pan Shortcuts';
-			case 'addons.zoom.shortcuts.descriptionZoom': return 'Zoom in and out';
-			case 'addons.zoom.shortcuts.keystrokeZoom': return 'Mouse Wheel';
-			case 'addons.zoom.shortcuts.descriptionReset': return 'Reset zoom';
-			case 'addons.zoom.shortcuts.descriptionZoomIn': return 'Zoom in';
-			case 'addons.zoom.shortcuts.descriptionZoomOut': return 'Zoom out';
-			case 'addons.zoom.shortcuts.descriptionPan': return 'Pan the view';
-			case 'addons.zoom.shortcuts.keystrokePan': return 'Left or Middle Mouse Button Drag';
-			case 'addons.zoom.shortcuts.descriptionZoomPan': return 'Zoom/Pan the view';
-			case 'addons.zoom.shortcuts.keystrokeZoomPan': return 'Zoom/Pan gestures on Trackpad';
-			case 'app.duplicatePathErrorTitleMessage': return 'Duplicate Paths Found';
-			case 'app.duplicatePathErrorContentMessageMarkdown': return ({required Object duplicatePath}) => 'There are multiple folders, components or use cases with the same path:\n${duplicatePath}\n\nRename some nodes such that all the paths are unique.';
-			case 'navigationPanel.lastUpdated': return ({required Object date}) => 'LAST UPDATED ${date}';
-			case 'navigationPanel.search.hint': return 'Search';
-			case 'navigationPanel.overview': return 'Overview';
-			case 'configurationPanel.nameCopiedNotificationMessage': return ({required Object name}) => '"${name}" copied to clipboard';
-			case 'configurationPanel.cantConfigureUseCaseInOverview': return 'Cannot configure the use case when overviewing it.';
-			case 'configurationPanel.noUseCaseSelected': return 'No use case selected';
-			case 'configurationPanel.tabs.configure': return 'CONFIGURE';
-			case 'configurationPanel.tabs.inspect': return 'INSPECT';
-			case 'configurationPanel.tabs.settings': return 'SETTINGS';
-			case 'shortcuts.general.title': return 'General';
-			case 'shortcuts.general.descriptionSearch': return 'Open/Focus search';
-			case 'shortcuts.general.descriptionTogglePanel': return 'Toggle Panels';
-			case 'shortcuts.general.descriptionHome': return 'Home';
-			case 'shortcuts.navigationMode.title': return 'Navigation Shortcuts';
-			case 'shortcuts.navigationMode.descriptionPrevious': return 'Navigate to the previous use case';
-			case 'shortcuts.navigationMode.keystrokePrevious': return 'Arrow Up / Page Up';
-			case 'shortcuts.navigationMode.descriptionNext': return 'Navigate to the next use case';
-			case 'shortcuts.navigationMode.keystrokeNext': return 'Arrow Down / Page Down';
-			case 'overview.overflow_notification.title': return 'Fix Overflows in the Overview';
-			case 'overview.overflow_notification.contentMarkdown': return 'You seem to be having issues with overflows in the overview.\nThis may be because the thumbnails provide to little space for the widget being displayed.\n\nThere are several ways in which you can control the presentation of the thumbnail,\nincluding setting the scale, which can effectively give the widget more space.\n\nExplore these methods by typing `c.overview.` in your use case\nand autocompleting the methods that are available.\n\nTake a look at the "Overview" topic in the API docs, which explains these methods in detail.';
-			case 'overview.overflow_notification.contentWithConstraintsAddonMarkdown': return '${_root.overview.overflow_notification.contentMarkdown}\n\nAdditionally, since you are using the `ConstraintsAddon`, note that the lower bounds given to\n`c.constraints.supported(...)` also set the minimum size that is used for the thumbnail\nunless `limitOverviewSize` is set to `false`.\nAlso by using for example `c.constraints.overview(...)` you can set the view constraints\nthat are used in the overview. If this is not set, the view constraints used in the\noverview falls back to the initial view constraints that are also used when\nviewing the use case.';
-			default: return null;
-		}
-	}
+  dynamic _flatMapFunction(String path) {
+    switch (path) {
+      case 'generic.yesNoSwitch.no':
+        return 'NO';
+      case 'generic.yesNoSwitch.yes':
+        return 'YES';
+      case 'generic.onOffSwitch.off':
+        return 'OFF';
+      case 'generic.onOffSwitch.on':
+        return 'ON';
+      case 'addons.accessibility.name':
+        return 'Accessibility';
+      case 'addons.accessibility.controls.textScaleFactor':
+        return 'Text Scale Factor';
+      case 'addons.accessibility.controls.boldText':
+        return 'Bold Text';
+      case 'addons.accessibility.controls.semanticsMode.name':
+        return 'Semantics Mode';
+      case 'addons.accessibility.controls.semanticsMode.values.none':
+        return 'None';
+      case 'addons.accessibility.controls.semanticsMode.values.overlay':
+        return 'Overlay';
+      case 'addons.accessibility.controls.semanticsMode.values.inspection':
+        return 'Inspection';
+      case 'addons.accessibility.controls.semanticsTree':
+        return 'Semantics Tree';
+      case 'addons.accessibility.controls.activeSemanticsNode':
+        return 'Active Semantics Node';
+      case 'addons.accessibility.controls.colorMode.name':
+        return 'Simulated Color Blindness';
+      case 'addons.accessibility.controls.colorMode.values.none':
+        return 'None';
+      case 'addons.accessibility.controls.colorMode.values.protanopia':
+        return 'Protanopia (red blindness)';
+      case 'addons.accessibility.controls.colorMode.values.deuteranopia':
+        return 'Deuteranopia (green blindness)';
+      case 'addons.accessibility.controls.colorMode.values.tritanopia':
+        return 'Tritanopia (blue blindness)';
+      case 'addons.accessibility.controls.colorMode.values.protanomaly':
+        return 'Protanomaly (red weakness)';
+      case 'addons.accessibility.controls.colorMode.values.deuteranomaly':
+        return 'Deuteranomaly (green weakness)';
+      case 'addons.accessibility.controls.colorMode.values.tritanomaly':
+        return 'Tritanomaly (blue weakness)';
+      case 'addons.accessibility.controls.colorMode.values.inverted':
+        return 'Inverted';
+      case 'addons.accessibility.controls.colorMode.values.grayscale':
+        return 'Grayscale';
+      case 'addons.accessibility.inspector.name':
+        return 'Semantics Inspector';
+      case 'addons.background.name':
+        return 'Background';
+      case 'addons.background.controls.background.label':
+        return 'Background';
+      case 'addons.background.controls.background.values.useCaseDefault':
+        return 'Use Case Default';
+      case 'addons.debugging.name':
+        return 'Debugging (Experimental)';
+      case 'addons.debugging.controls.performanceOverlay':
+        return 'Performance Overlay';
+      case 'addons.debugging.controls.paintBaselines':
+        return 'Paint Baselines';
+      case 'addons.debugging.controls.paintSize':
+        return 'Paint Size';
+      case 'addons.debugging.controls.repaintTextRainbow':
+        return 'Repaint Text Rainbow';
+      case 'addons.debugging.controls.repaintRainbow':
+        return 'Repaint Rainbow';
+      case 'addons.debugging.controls.timeDilation':
+        return 'Time Dilation';
+      case 'addons.hotReloadEffect.name':
+        return 'Hot Reload Effect';
+      case 'addons.hotReloadEffect.controls.hotReloadEffect':
+        return 'Hot Reload Effect';
+      case 'addons.knobs.name':
+        return 'Knobs';
+      case 'addons.knobs.controls.preset.name':
+        return 'Preset';
+      case 'addons.knobs.controls.preset.values.initial':
+        return 'Initial';
+      case 'addons.knobs.controls.preset.values.unknown':
+        return '-';
+      case 'addons.knobs.knobs.boolean.values.falseLabel':
+        return 'FALSE';
+      case 'addons.knobs.knobs.boolean.values.trueLabel':
+        return 'TRUE';
+      case 'addons.knobs.knobs.interval.begin':
+        return 'Begin';
+      case 'addons.knobs.knobs.interval.end':
+        return 'End';
+      case 'addons.knobs.knobs.focusnode.unfocused':
+        return 'Unfocused';
+      case 'addons.knobs.knobs.focusnode.focused':
+        return 'Focused';
+      case 'addons.localization.name':
+        return 'Localization';
+      case 'addons.localization.controls.locale':
+        return 'Locale';
+      case 'addons.ordering.name':
+        return 'Ordering';
+      case 'addons.ordering.controls.order.name':
+        return 'Order';
+      case 'addons.ordering.controls.order.values.code':
+        return 'Code';
+      case 'addons.ordering.controls.order.values.alphabetical':
+        return 'Alphabetical';
+      case 'addons.colorPicker.name':
+        return 'Color Picker';
+      case 'addons.colorPicker.controls.colorPicker.name':
+        return 'Color Picker';
+      case 'addons.colorPicker.controls.colorPicker.values.color':
+        return 'Color';
+      case 'addons.colorPicker.controls.colorPicker.values.noSelectedColor':
+        return 'No color selected';
+      case 'addons.colorPicker.controls.colorPicker.values.colorCopied':
+        return 'Hex Code copied to clipboard';
+      case 'addons.colorPicker.controls.colorPicker.values.pickedColor':
+        return 'Picked Color';
+      case 'addons.description.component':
+        return ({required Object name}) => '${name} (Component)';
+      case 'addons.description.folder':
+        return ({required Object name}) => '${name} (Folder)';
+      case 'addons.description.sections':
+        return '(Sections)';
+      case 'addons.description.tags':
+        return 'Tags';
+      case 'addons.description.description':
+        return 'Description';
+      case 'addons.description.links':
+        return 'External Links';
+      case 'addons.pageTransition.name':
+        return 'Page Transition';
+      case 'addons.recentHistory.homePageComponentTitle':
+        return 'Recently Visited';
+      case 'addons.acknowledged.homePageComponentTitle':
+        return 'Recently Added';
+      case 'addons.constraints.name':
+        return 'Constraints';
+      case 'addons.constraints.controls.preset.name':
+        return 'Preset';
+      case 'addons.constraints.controls.preset.values.initial':
+        return 'Initial';
+      case 'addons.constraints.controls.preset.values.unknown':
+        return '-';
+      case 'addons.constraints.controls.constraints.name':
+        return 'Constraints';
+      case 'addons.constraints.controls.constraints.values.minWidth':
+        return 'Min Width';
+      case 'addons.constraints.controls.constraints.values.maxWidth':
+        return 'Max Width';
+      case 'addons.constraints.controls.constraints.values.minHeight':
+        return 'Min Height';
+      case 'addons.constraints.controls.constraints.values.maxHeight':
+        return 'Max Height';
+      case 'addons.constraints.controls.size.name':
+        return 'Size';
+      case 'addons.constraints.controls.size.values.width':
+        return 'Width';
+      case 'addons.constraints.controls.size.values.height':
+        return 'Height';
+      case 'addons.constraints.shortcuts.title':
+        return 'Constraints Mode Change Shortcuts';
+      case 'addons.constraints.shortcuts.subTitle':
+        return 'Use the ruler to size one axis to tight constraints';
+      case 'addons.constraints.shortcuts.descriptionResize':
+        return 'Resize both axes to tight constraints';
+      case 'addons.constraints.shortcuts.descriptionMinSize':
+        return 'Apply minimum size constraints';
+      case 'addons.constraints.shortcuts.descriptionMaxSize':
+        return 'Apply maximum size constraints';
+      case 'addons.werkbank_theme.name':
+        return 'Werkbank Theme';
+      case 'addons.werkbank_theme.controls.theme':
+        return 'Theme';
+      case 'addons.theming.name':
+        return 'Theming';
+      case 'addons.theming.controls.theme':
+        return 'Theme';
+      case 'addons.zoom.name':
+        return 'Zoom';
+      case 'addons.zoom.controls.enabled':
+        return 'Enabled';
+      case 'addons.zoom.controls.magnification':
+        return 'Magnification';
+      case 'addons.zoom.shortcuts.title':
+        return 'Zoom/Pan Shortcuts';
+      case 'addons.zoom.shortcuts.descriptionZoom':
+        return 'Zoom in and out';
+      case 'addons.zoom.shortcuts.keystrokeZoom':
+        return 'Mouse Wheel';
+      case 'addons.zoom.shortcuts.descriptionReset':
+        return 'Reset zoom';
+      case 'addons.zoom.shortcuts.descriptionZoomIn':
+        return 'Zoom in';
+      case 'addons.zoom.shortcuts.descriptionZoomOut':
+        return 'Zoom out';
+      case 'addons.zoom.shortcuts.descriptionPan':
+        return 'Pan the view';
+      case 'addons.zoom.shortcuts.keystrokePan':
+        return 'Left or Middle Mouse Button Drag';
+      case 'addons.zoom.shortcuts.descriptionZoomPan':
+        return 'Zoom/Pan the view';
+      case 'addons.zoom.shortcuts.keystrokeZoomPan':
+        return 'Zoom/Pan gestures on Trackpad';
+      case 'app.duplicatePathErrorTitleMessage':
+        return 'Duplicate Paths Found';
+      case 'app.duplicatePathErrorContentMessageMarkdown':
+        return ({required Object duplicatePath}) =>
+            'There are multiple folders, components or use cases with the same path:\n${duplicatePath}\n\nRename some nodes such that all the paths are unique.';
+      case 'navigationPanel.lastUpdated':
+        return ({required Object date}) => 'LAST UPDATED ${date}';
+      case 'navigationPanel.search.hint':
+        return 'Search';
+      case 'navigationPanel.overview':
+        return 'Overview';
+      case 'configurationPanel.nameCopiedNotificationMessage':
+        return ({required Object name}) => '"${name}" copied to clipboard';
+      case 'configurationPanel.cantConfigureUseCaseInOverview':
+        return 'Cannot configure the use case when overviewing it.';
+      case 'configurationPanel.noUseCaseSelected':
+        return 'No use case selected';
+      case 'configurationPanel.tabs.configure':
+        return 'CONFIGURE';
+      case 'configurationPanel.tabs.inspect':
+        return 'INSPECT';
+      case 'configurationPanel.tabs.settings':
+        return 'SETTINGS';
+      case 'shortcuts.general.title':
+        return 'General';
+      case 'shortcuts.general.descriptionSearch':
+        return 'Open/Focus search';
+      case 'shortcuts.general.descriptionTogglePanel':
+        return 'Toggle Panels';
+      case 'shortcuts.general.descriptionHome':
+        return 'Home';
+      case 'shortcuts.navigationMode.title':
+        return 'Navigation Shortcuts';
+      case 'shortcuts.navigationMode.descriptionPrevious':
+        return 'Navigate to the previous use case';
+      case 'shortcuts.navigationMode.keystrokePrevious':
+        return 'Arrow Up / Page Up';
+      case 'shortcuts.navigationMode.descriptionNext':
+        return 'Navigate to the next use case';
+      case 'shortcuts.navigationMode.keystrokeNext':
+        return 'Arrow Down / Page Down';
+      case 'overview.overflow_notification.title':
+        return 'Fix Overflows in the Overview';
+      case 'overview.overflow_notification.contentMarkdown':
+        return 'You seem to be having issues with overflows in the overview.\nThis may be because the thumbnails provide to little space for the widget being displayed.\n\nThere are several ways in which you can control the presentation of the thumbnail,\nincluding setting the scale, which can effectively give the widget more space.\n\nExplore these methods by typing `c.overview.` in your use case\nand autocompleting the methods that are available.\n\nTake a look at the "Overview" topic in the API docs, which explains these methods in detail.';
+      case 'overview.overflow_notification.contentWithConstraintsAddonMarkdown':
+        return '${_root.overview.overflow_notification.contentMarkdown}\n\nAdditionally, since you are using the `ConstraintsAddon`, note that the lower bounds given to\n`c.constraints.supported(...)` also set the minimum size that is used for the thumbnail\nunless `limitOverviewSize` is set to `false`.\nAlso by using for example `c.constraints.overview(...)` you can set the view constraints\nthat are used in the overview. If this is not set, the view constraints used in the\noverview falls back to the initial view constraints that are also used when\nviewing the use case.';
+      default:
+        return null;
+    }
+  }
 }
-

--- a/packages/werkbank/lib/src/_internal/src/package_copies/dropdown_button2/src/dropdown_button2.dart
+++ b/packages/werkbank/lib/src/_internal/src/package_copies/dropdown_button2/src/dropdown_button2.dart
@@ -23,23 +23,29 @@ const Duration _kDropdownMenuDuration = Duration(milliseconds: 300);
 const double _kMenuItemHeight = kMinInteractiveDimension;
 const double _kDenseButtonHeight = 24.0;
 const EdgeInsets _kMenuItemPadding = EdgeInsets.symmetric(horizontal: 16.0);
-const EdgeInsetsGeometry _kAlignedButtonPadding = EdgeInsetsDirectional.only(start: 16.0, end: 4.0);
+const EdgeInsetsGeometry _kAlignedButtonPadding = EdgeInsetsDirectional.only(
+  start: 16.0,
+  end: 4.0,
+);
 const EdgeInsets _kUnalignedButtonPadding = EdgeInsets.zero;
 
 /// A builder to customize the selected menu item.
-typedef SelectedMenuItemBuilder = Widget Function(BuildContext context, Widget child);
+typedef SelectedMenuItemBuilder =
+    Widget Function(BuildContext context, Widget child);
 
 /// Signature for the callback that's called when when the dropdown menu opens or closes.
 typedef OnMenuStateChangeFn = void Function(bool isOpen);
 
 /// Signature for the callback for the match function used for searchable dropdowns.
-typedef SearchMatchFn<T> = bool Function(
-  DropdownMenuItem<T> item,
-  String searchValue,
-);
+typedef SearchMatchFn<T> =
+    bool Function(
+      DropdownMenuItem<T> item,
+      String searchValue,
+    );
 
-SearchMatchFn<T> _defaultSearchMatchFn<T>() => (DropdownMenuItem<T> item, String searchValue) =>
-    item.value.toString().toLowerCase().contains(searchValue.toLowerCase());
+SearchMatchFn<T> _defaultSearchMatchFn<T>() =>
+    (DropdownMenuItem<T> item, String searchValue) =>
+        item.value.toString().toLowerCase().contains(searchValue.toLowerCase());
 
 class _DropdownMenuPainter extends CustomPainter {
   _DropdownMenuPainter({
@@ -49,21 +55,24 @@ class _DropdownMenuPainter extends CustomPainter {
     required this.resize,
     required this.itemHeight,
     this.dropdownDecoration,
-  })  : _painter = dropdownDecoration
-                ?.copyWith(
-                  color: dropdownDecoration.color ?? color,
-                  boxShadow: dropdownDecoration.boxShadow ?? kElevationToShadow[elevation],
-                )
-                .createBoxPainter(() {}) ??
-            BoxDecoration(
-              // If you add an image here, you must provide a real
-              // configuration in the paint() function and you must provide some sort
-              // of onChanged callback here.
-              color: color,
-              borderRadius: const BorderRadius.all(Radius.circular(2.0)),
-              boxShadow: kElevationToShadow[elevation],
-            ).createBoxPainter(),
-        super(repaint: resize);
+  }) : _painter =
+           dropdownDecoration
+               ?.copyWith(
+                 color: dropdownDecoration.color ?? color,
+                 boxShadow:
+                     dropdownDecoration.boxShadow ??
+                     kElevationToShadow[elevation],
+               )
+               .createBoxPainter(() {}) ??
+           BoxDecoration(
+             // If you add an image here, you must provide a real
+             // configuration in the paint() function and you must provide some sort
+             // of onChanged callback here.
+             color: color,
+             borderRadius: const BorderRadius.all(Radius.circular(2.0)),
+             boxShadow: kElevationToShadow[elevation],
+           ).createBoxPainter(),
+       super(repaint: resize);
 
   final Color? color;
   final int? elevation;
@@ -84,11 +93,20 @@ class _DropdownMenuPainter extends CustomPainter {
     );
 
     final Tween<double> bottom = Tween<double>(
-      begin: _clampDouble(top.begin! + itemHeight, math.min(itemHeight, size.height), size.height),
+      begin: _clampDouble(
+        top.begin! + itemHeight,
+        math.min(itemHeight, size.height),
+        size.height,
+      ),
       end: size.height,
     );
 
-    final Rect rect = Rect.fromLTRB(0.0, top.evaluate(resize), size.width, bottom.evaluate(resize));
+    final Rect rect = Rect.fromLTRB(
+      0.0,
+      top.evaluate(resize),
+      size.width,
+      bottom.evaluate(resize),
+    );
 
     _painter.paint(canvas, rect.topLeft, ImageConfiguration(size: rect.size));
   }
@@ -126,10 +144,12 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final bool enableFeedback;
 
   @override
-  _DropdownMenuItemButtonState<T> createState() => _DropdownMenuItemButtonState<T>();
+  _DropdownMenuItemButtonState<T> createState() =>
+      _DropdownMenuItemButtonState<T>();
 }
 
-class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> {
+class _DropdownMenuItemButtonState<T>
+    extends State<_DropdownMenuItemButton<T>> {
   void _handleFocusChange(bool focused) {
     final bool inTraditionalMode;
     switch (FocusManager.instance.highlightMode) {
@@ -158,7 +178,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
   }
 
   void _handleOnTap() {
-    final DropdownMenuItem<T> dropdownMenuItem = widget.route.items[widget.itemIndex].item!;
+    final DropdownMenuItem<T> dropdownMenuItem =
+        widget.route.items[widget.itemIndex].item!;
 
     dropdownMenuItem.onTap?.call();
 
@@ -168,12 +189,17 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     );
   }
 
-  static const Map<ShortcutActivator, Intent> _webShortcuts = <ShortcutActivator, Intent>{
-    // On the web, up/down don't change focus, *except* in a <select>
-    // element, which is what a dropdown emulates.
-    SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
-    SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
-  };
+  static const Map<ShortcutActivator, Intent> _webShortcuts =
+      <ShortcutActivator, Intent>{
+        // On the web, up/down don't change focus, *except* in a <select>
+        // element, which is what a dropdown emulates.
+        SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+          TraversalDirection.down,
+        ),
+        SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+          TraversalDirection.up,
+        ),
+      };
 
   MenuItemStyleData get menuItemStyle => widget.route.menuItemStyle;
 
@@ -181,15 +207,24 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
   Widget build(BuildContext context) {
     final double menuCurveEnd = widget.route.dropdownStyle.openInterval.end;
 
-    final DropdownMenuItem<T> dropdownMenuItem = widget.route.items[widget.itemIndex].item!;
+    final DropdownMenuItem<T> dropdownMenuItem =
+        widget.route.items[widget.itemIndex].item!;
     final double unit = 0.5 / (widget.route.items.length + 1.5);
-    final double start = _clampDouble(menuCurveEnd + (widget.itemIndex + 1) * unit, 0.0, 1.0);
+    final double start = _clampDouble(
+      menuCurveEnd + (widget.itemIndex + 1) * unit,
+      0.0,
+      1.0,
+    );
     final double end = _clampDouble(start + 1.5 * unit, 0.0, 1.0);
-    final CurvedAnimation opacity =
-        CurvedAnimation(parent: widget.route.animation!, curve: Interval(start, end));
+    final CurvedAnimation opacity = CurvedAnimation(
+      parent: widget.route.animation!,
+      curve: Interval(start, end),
+    );
 
     Widget child = Container(
-      padding: (menuItemStyle.padding ?? _kMenuItemPadding).resolve(widget.textDirection),
+      padding: (menuItemStyle.padding ?? _kMenuItemPadding).resolve(
+        widget.textDirection,
+      ),
       height: menuItemStyle.customHeights == null
           ? menuItemStyle.height
           : menuItemStyle.customHeights![widget.itemIndex],
@@ -199,7 +234,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     // isNoSelectedItem to avoid first item highlight when no item selected
     if (dropdownMenuItem.enabled) {
       final bool isSelectedItem =
-          !widget.route.isNoSelectedItem && widget.itemIndex == widget.route.selectedIndex;
+          !widget.route.isNoSelectedItem &&
+          widget.itemIndex == widget.route.selectedIndex;
       child = InkWell(
         autofocus: isSelectedItem,
         enableFeedback: widget.enableFeedback,
@@ -207,7 +243,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
         onFocusChange: _handleFocusChange,
         overlayColor: menuItemStyle.overlayColor,
         child: isSelectedItem
-            ? menuItemStyle.selectedMenuItemBuilder?.call(context, child) ?? child
+            ? menuItemStyle.selectedMenuItemBuilder?.call(context, child) ??
+                  child
             : child,
       );
     }
@@ -333,41 +370,42 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
 
   ScrollbarThemeData? get _scrollbarTheme => dropdownStyle.scrollbarTheme;
 
-  bool? get _iOSThumbVisibility => _scrollbarTheme?.thumbVisibility?.resolve(_states);
+  bool? get _iOSThumbVisibility =>
+      _scrollbarTheme?.thumbVisibility?.resolve(_states);
 
   Widget get _materialScrollBar => Theme(
-        data: Theme.of(context).copyWith(
-          scrollbarTheme: dropdownStyle.scrollbarTheme,
-        ),
-        child: Scrollbar(
-          thumbVisibility: true,
-          child: ListView(
-            // Ensure this always inherits the PrimaryScrollController
-            primary: true,
-            padding: dropdownStyle.padding ?? kMaterialListPadding,
-            shrinkWrap: true,
-            children: _children,
-          ),
-        ),
-      );
+    data: Theme.of(context).copyWith(
+      scrollbarTheme: dropdownStyle.scrollbarTheme,
+    ),
+    child: Scrollbar(
+      thumbVisibility: true,
+      child: ListView(
+        // Ensure this always inherits the PrimaryScrollController
+        primary: true,
+        padding: dropdownStyle.padding ?? kMaterialListPadding,
+        shrinkWrap: true,
+        children: _children,
+      ),
+    ),
+  );
 
   Widget get _cupertinoScrollBar => Theme(
-        data: Theme.of(context).copyWith(
-          scrollbarTheme: dropdownStyle.scrollbarTheme,
-        ),
-        child: Scrollbar(
-          thumbVisibility: _iOSThumbVisibility ?? true,
-          thickness: _scrollbarTheme?.thickness?.resolve(_states),
-          radius: _scrollbarTheme?.radius,
-          child: ListView(
-            // Ensure this always inherits the PrimaryScrollController
-            primary: true,
-            padding: dropdownStyle.padding ?? kMaterialListPadding,
-            shrinkWrap: true,
-            children: _children,
-          ),
-        ),
-      );
+    data: Theme.of(context).copyWith(
+      scrollbarTheme: dropdownStyle.scrollbarTheme,
+    ),
+    child: Scrollbar(
+      thumbVisibility: _iOSThumbVisibility ?? true,
+      thickness: _scrollbarTheme?.thickness?.resolve(_states),
+      radius: _scrollbarTheme?.radius,
+      child: ListView(
+        // Ensure this always inherits the PrimaryScrollController
+        primary: true,
+        padding: dropdownStyle.padding ?? kMaterialListPadding,
+        shrinkWrap: true,
+        children: _children,
+      ),
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -380,7 +418,9 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
     // When the menu is dismissed we just fade the entire thing out
     // in the first 0.25s.
     assert(debugCheckHasMaterialLocalizations(context));
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final MaterialLocalizations localizations = MaterialLocalizations.of(
+      context,
+    );
     final _DropdownRoute<T> route = widget.route;
 
     return FadeTransition(
@@ -401,18 +441,22 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           label: localizations.popupMenuLabel,
           child: ClipRRect(
             //Prevent scrollbar, ripple effect & items from going beyond border boundaries when scrolling.
-            clipBehavior:
-                dropdownStyle.decoration?.borderRadius != null ? Clip.antiAlias : Clip.none,
+            clipBehavior: dropdownStyle.decoration?.borderRadius != null
+                ? Clip.antiAlias
+                : Clip.none,
             borderRadius:
-                dropdownStyle.decoration?.borderRadius?.resolve(Directionality.of(context)) ??
-                    BorderRadius.zero,
+                dropdownStyle.decoration?.borderRadius?.resolve(
+                  Directionality.of(context),
+                ) ??
+                BorderRadius.zero,
             child: Material(
               type: MaterialType.transparency,
               textStyle: route.style,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  if (searchData?.searchInnerWidget != null) searchData!.searchInnerWidget!,
+                  if (searchData?.searchInnerWidget != null)
+                    searchData!.searchInnerWidget!,
                   Flexible(
                     child: Padding(
                       padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
@@ -428,7 +472,9 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
                         ),
                         child: PrimaryScrollController(
                           controller: route.scrollController!,
-                          child: _isIOS ? _cupertinoScrollBar : _materialScrollBar,
+                          child: _isIOS
+                              ? _cupertinoScrollBar
+                              : _materialScrollBar,
                         ),
                       ),
                     ),
@@ -461,14 +507,20 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
     final double? itemWidth = route.dropdownStyle.width;
-    double maxHeight = route.getMenuAvailableHeight(availableHeight, mediaQueryPadding);
+    double maxHeight = route.getMenuAvailableHeight(
+      availableHeight,
+      mediaQueryPadding,
+    );
     final double? preferredMaxHeight = route.dropdownStyle.maxHeight;
     if (preferredMaxHeight != null && preferredMaxHeight <= maxHeight) {
       maxHeight = preferredMaxHeight;
     }
     // The width of a menu should be at most the view width. This ensures that
     // the menu does not extend past the left and right edges of the screen.
-    final double width = math.min(constraints.maxWidth, itemWidth ?? buttonRect.width);
+    final double width = math.min(
+      constraints.maxWidth,
+      itemWidth ?? buttonRect.width,
+    );
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,
@@ -541,7 +593,8 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_DropdownMenuRouteLayout<T> oldDelegate) {
-    return buttonRect != oldDelegate.buttonRect || textDirection != oldDelegate.textDirection;
+    return buttonRect != oldDelegate.buttonRect ||
+        textDirection != oldDelegate.textDirection;
   }
 }
 
@@ -588,7 +641,8 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     required this.menuItemStyle,
     required this.searchData,
   }) : itemHeights =
-            menuItemStyle.customHeights ?? List<double>.filled(items.length, menuItemStyle.height);
+           menuItemStyle.customHeights ??
+           List<double>.filled(items.length, menuItemStyle.height);
 
   final List<_MenuItem<T>> items;
   final ValueNotifier<Rect?> buttonRect;
@@ -618,7 +672,10 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
 
   @override
   Widget buildPage(
-      BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
     return LayoutBuilder(
       builder: (BuildContext ctx, BoxConstraints constraints) {
         //Exclude BottomInset from maxHeight to avoid overlapping menu items
@@ -626,10 +683,12 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
         //This will ensure menu is drawn in the actual available height.
         // TODO(Ahmed): use paddingOf/paddingOf [flutter>=v3.10.0].
         final MediaQueryData mediaQuery = MediaQuery.of(ctx);
-        final BoxConstraints actualConstraints =
-            constraints.copyWith(maxHeight: constraints.maxHeight - mediaQuery.viewInsets.bottom);
-        final EdgeInsets mediaQueryPadding =
-            dropdownStyle.useSafeArea ? mediaQuery.padding : EdgeInsets.zero;
+        final BoxConstraints actualConstraints = constraints.copyWith(
+          maxHeight: constraints.maxHeight - mediaQuery.viewInsets.bottom,
+        );
+        final EdgeInsets mediaQueryPadding = dropdownStyle.useSafeArea
+            ? mediaQuery.padding
+            : EdgeInsets.zero;
         return ValueListenableBuilder<Rect?>(
           valueListenable: buttonRect,
           builder: (BuildContext context, Rect? rect, _) {
@@ -659,8 +718,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     double offset = paddingTop;
     if (items.isNotEmpty && index > 0) {
       assert(items.length == itemHeights.length);
-      offset +=
-          itemHeights.sublist(0, index).reduce((double total, double height) => total + height);
+      offset += itemHeights
+          .sublist(0, index)
+          .reduce((double total, double height) => total + height);
     }
     return offset;
   }
@@ -673,18 +733,24 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     EdgeInsets mediaQueryPadding,
     int index,
   ) {
-    double maxHeight = getMenuAvailableHeight(availableHeight, mediaQueryPadding);
+    double maxHeight = getMenuAvailableHeight(
+      availableHeight,
+      mediaQueryPadding,
+    );
     // If a preferred MaxHeight is set by the user, use it instead of the available maxHeight.
     final double? preferredMaxHeight = dropdownStyle.maxHeight;
     if (preferredMaxHeight != null) {
       maxHeight = math.min(maxHeight, preferredMaxHeight);
     }
 
-    double actualMenuHeight = dropdownStyle.padding?.vertical ?? kMaterialListPadding.vertical;
+    double actualMenuHeight =
+        dropdownStyle.padding?.vertical ?? kMaterialListPadding.vertical;
     final double innerWidgetHeight = searchData?.searchInnerWidgetHeight ?? 0.0;
     actualMenuHeight += innerWidgetHeight;
     if (items.isNotEmpty) {
-      actualMenuHeight += itemHeights.reduce((double total, double height) => total + height);
+      actualMenuHeight += itemHeights.reduce(
+        (double total, double height) => total + height,
+      );
     }
 
     // Use actualMenuHeight if it's less than maxHeight.
@@ -727,7 +793,11 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
           : kMaterialListPadding.top;
       final double selectedItemOffset = getItemOffset(index, paddingTop);
       scrollOffset = math.max(
-          0.0, selectedItemOffset - (menuNetHeight / 2) + (itemHeights[selectedIndex] / 2));
+        0.0,
+        selectedItemOffset -
+            (menuNetHeight / 2) +
+            (itemHeights[selectedIndex] / 2),
+      );
       // If the selected item's scroll offset is greater than the maximum scroll offset,
       // set it instead to the maximum allowed scroll offset.
       final double maxScrollOffset = actualMenuNetHeight - menuNetHeight;
@@ -794,7 +864,9 @@ class _DropdownRoutePage<T> extends StatelessWidget {
         mediaQueryPadding,
         selectedIndex,
       );
-      route.scrollController = ScrollController(initialScrollOffset: menuLimits.scrollOffset);
+      route.scrollController = ScrollController(
+        initialScrollOffset: menuLimits.scrollOffset,
+      );
     }
 
     final TextDirection? textDirection = Directionality.maybeOf(context);
@@ -852,7 +924,10 @@ class _MenuItem<T> extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, covariant _RenderMenuItem renderObject) {
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderMenuItem renderObject,
+  ) {
     renderObject.onLayout = onLayout;
   }
 }
@@ -987,29 +1062,29 @@ class DropdownButton2<T> extends StatefulWidget {
     this.barrierLabel,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
-  })  : assert(
-          items == null ||
-              items.isEmpty ||
-              value == null ||
-              items.where((DropdownMenuItem<T> item) {
-                    return item.value == value;
-                  }).length ==
-                  1,
-          "There should be exactly one item with [DropdownButton]'s value: "
-          '$value. \n'
-          'Either zero or 2 or more [DropdownMenuItem]s were detected '
-          'with the same value',
-        ),
-        assert(
-          menuItemStyleData.customHeights == null ||
-              items == null ||
-              items.isEmpty ||
-              menuItemStyleData.customHeights?.length == items.length,
-          'customHeights list should have the same length of items list',
-        ),
-        _inputDecoration = null,
-        _isEmpty = false,
-        _isFocused = false;
+  }) : assert(
+         items == null ||
+             items.isEmpty ||
+             value == null ||
+             items.where((DropdownMenuItem<T> item) {
+                   return item.value == value;
+                 }).length ==
+                 1,
+         "There should be exactly one item with [DropdownButton]'s value: "
+         '$value. \n'
+         'Either zero or 2 or more [DropdownMenuItem]s were detected '
+         'with the same value',
+       ),
+       assert(
+         menuItemStyleData.customHeights == null ||
+             items == null ||
+             items.isEmpty ||
+             menuItemStyleData.customHeights?.length == items.length,
+         'customHeights list should have the same length of items list',
+       ),
+       _inputDecoration = null,
+       _isEmpty = false,
+       _isFocused = false;
 
   DropdownButton2._formField({
     super.key,
@@ -1041,29 +1116,29 @@ class DropdownButton2<T> extends StatefulWidget {
     required InputDecoration inputDecoration,
     required bool isEmpty,
     required bool isFocused,
-  })  : assert(
-          items == null ||
-              items.isEmpty ||
-              value == null ||
-              items.where((DropdownMenuItem<T> item) {
-                    return item.value == value;
-                  }).length ==
-                  1,
-          "There should be exactly one item with [DropdownButtonFormField]'s value: "
-          '$value. \n'
-          'Either zero or 2 or more [DropdownMenuItem]s were detected '
-          'with the same value',
-        ),
-        assert(
-          menuItemStyleData.customHeights == null ||
-              items == null ||
-              items.isEmpty ||
-              menuItemStyleData.customHeights?.length == items.length,
-          'customHeights list should have the same length of items list',
-        ),
-        _inputDecoration = inputDecoration,
-        _isEmpty = isEmpty,
-        _isFocused = isFocused;
+  }) : assert(
+         items == null ||
+             items.isEmpty ||
+             value == null ||
+             items.where((DropdownMenuItem<T> item) {
+                   return item.value == value;
+                 }).length ==
+                 1,
+         "There should be exactly one item with [DropdownButtonFormField]'s value: "
+         '$value. \n'
+         'Either zero or 2 or more [DropdownMenuItem]s were detected '
+         'with the same value',
+       ),
+       assert(
+         menuItemStyleData.customHeights == null ||
+             items == null ||
+             items.isEmpty ||
+             menuItemStyleData.customHeights?.length == items.length,
+         'customHeights list should have the same length of items list',
+       ),
+       _inputDecoration = inputDecoration,
+       _isEmpty = isEmpty,
+       _isFocused = isFocused;
 
   /// The list of items the user can select.
   ///
@@ -1242,7 +1317,8 @@ class DropdownButton2<T> extends StatefulWidget {
 }
 
 // ignore: public_member_api_docs
-class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBindingObserver {
+class DropdownButton2State<T> extends State<DropdownButton2<T>>
+    with WidgetsBindingObserver {
   int? _selectedIndex;
   _DropdownRoute<T>? _dropdownRoute;
   Orientation? _lastOrientation;
@@ -1319,14 +1395,21 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
         widget.items!.isEmpty ||
         (widget.value == null &&
             widget.items!
-                .where((DropdownMenuItem<T> item) => item.enabled && item.value == widget.value)
+                .where(
+                  (DropdownMenuItem<T> item) =>
+                      item.enabled && item.value == widget.value,
+                )
                 .isEmpty)) {
       _selectedIndex = null;
       return;
     }
 
     assert(
-        widget.items!.where((DropdownMenuItem<T> item) => item.value == widget.value).length == 1);
+      widget.items!
+              .where((DropdownMenuItem<T> item) => item.value == widget.value)
+              .length ==
+          1,
+    );
     for (int itemIndex = 0; itemIndex < widget.items!.length; itemIndex++) {
       if (widget.items![itemIndex].value == widget.value) {
         _selectedIndex = itemIndex;
@@ -1349,18 +1432,25 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
     _rect.value = newRect;
   }
 
-  TextStyle? get _textStyle => widget.style ?? Theme.of(context).textTheme.titleMedium;
+  TextStyle? get _textStyle =>
+      widget.style ?? Theme.of(context).textTheme.titleMedium;
 
   Rect _getRect() {
     final TextDirection? textDirection = Directionality.maybeOf(context);
     const EdgeInsetsGeometry menuMargin = EdgeInsets.zero;
-    final NavigatorState navigator = Navigator.of(context,
-        rootNavigator: _dropdownStyle.isFullScreen ?? _dropdownStyle.useRootNavigator);
+    final NavigatorState navigator = Navigator.of(
+      context,
+      rootNavigator:
+          _dropdownStyle.isFullScreen ?? _dropdownStyle.useRootNavigator,
+    );
 
     final RenderBox itemBox = context.findRenderObject()! as RenderBox;
     final Rect itemRect =
-        itemBox.localToGlobal(Offset.zero, ancestor: navigator.context.findRenderObject()) &
-            itemBox.size;
+        itemBox.localToGlobal(
+          Offset.zero,
+          ancestor: navigator.context.findRenderObject(),
+        ) &
+        itemBox.size;
 
     return menuMargin.resolve(textDirection).inflateRect(itemRect);
   }
@@ -1368,8 +1458,8 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
   double _getMenuHorizontalPadding() {
     final double menuHorizontalPadding =
         (_menuItemStyle.padding?.horizontal ?? _kMenuItemPadding.horizontal) +
-            (_dropdownStyle.padding?.horizontal ?? 0.0) +
-            (_dropdownStyle.scrollPadding?.horizontal ?? 0.0);
+        (_dropdownStyle.padding?.horizontal ?? 0.0) +
+        (_dropdownStyle.scrollPadding?.horizontal ?? 0.0);
     return menuHorizontalPadding / 2;
   }
 
@@ -1396,8 +1486,11 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
         ),
     ];
 
-    final NavigatorState navigator = Navigator.of(context,
-        rootNavigator: _dropdownStyle.isFullScreen ?? _dropdownStyle.useRootNavigator);
+    final NavigatorState navigator = Navigator.of(
+      context,
+      rootNavigator:
+          _dropdownStyle.isFullScreen ?? _dropdownStyle.useRootNavigator,
+    );
     assert(_dropdownRoute == null);
     _rect.value = _getRect();
     _dropdownRoute = _DropdownRoute<T>(
@@ -1405,12 +1498,16 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
       buttonRect: _rect,
       selectedIndex: _selectedIndex ?? 0,
       isNoSelectedItem: _selectedIndex == null,
-      capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
+      capturedThemes: InheritedTheme.capture(
+        from: context,
+        to: navigator.context,
+      ),
       style: _textStyle!,
       barrierDismissible: widget.barrierDismissible,
       barrierColor: widget.barrierColor,
       barrierLabel:
-          widget.barrierLabel ?? MaterialLocalizations.of(context).modalBarrierDismissLabel,
+          widget.barrierLabel ??
+          MaterialLocalizations.of(context).modalBarrierDismissLabel,
       enableFeedback: widget.enableFeedback ?? true,
       dropdownStyle: _dropdownStyle,
       menuItemStyle: _menuItemStyle,
@@ -1424,7 +1521,9 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
     Future.delayed(const Duration(milliseconds: 20), () {
       _focusNode?.requestFocus();
     });
-    navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
+    navigator.push(_dropdownRoute!).then<void>((
+      _DropdownRouteResult<T>? newValue,
+    ) {
       _removeDropdownRoute();
       _isMenuOpen.value = false;
       _focusNode?.unfocus();
@@ -1449,9 +1548,13 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
   double get _denseButtonHeight {
     final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
     final double fontSize =
-        _textStyle!.fontSize ?? Theme.of(context).textTheme.titleMedium!.fontSize!;
+        _textStyle!.fontSize ??
+        Theme.of(context).textTheme.titleMedium!.fontSize!;
     final double scaledFontSize = textScaleFactor * fontSize;
-    return math.max(scaledFontSize, math.max(_iconStyle.iconSize, _kDenseButtonHeight));
+    return math.max(
+      scaledFontSize,
+      math.max(_iconStyle.iconSize, _kDenseButtonHeight),
+    );
   }
 
   Color get _iconColor {
@@ -1481,7 +1584,10 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
     }
   }
 
-  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.onChanged != null;
+  bool get _enabled =>
+      widget.items != null &&
+      widget.items!.isNotEmpty &&
+      widget.onChanged != null;
 
   Orientation _getOrientation(BuildContext context) {
     // TODO(Ahmed): use maybeOrientationOf [flutter>=v3.10.0].
@@ -1492,7 +1598,9 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
       // TODO(Ahmed): use View.of(context) and update the comment [flutter>=v3.10.0].
       // ignore: deprecated_member_use
       final Size size = WidgetsBinding.instance.window.physicalSize;
-      result = size.width > size.height ? Orientation.landscape : Orientation.portrait;
+      result = size.width > size.height
+          ? Orientation.landscape
+          : Orientation.portrait;
     }
     return result;
   }
@@ -1533,22 +1641,27 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
 
     int? hintIndex;
     if (widget.hint != null || (!_enabled && widget.disabledHint != null)) {
-      final Widget displayedHint = _enabled ? widget.hint! : widget.disabledHint ?? widget.hint!;
+      final Widget displayedHint = _enabled
+          ? widget.hint!
+          : widget.disabledHint ?? widget.hint!;
 
       hintIndex = items.length;
-      items.add(DefaultTextStyle(
-        style: _textStyle!.copyWith(color: Theme.of(context).hintColor),
-        child: IgnorePointer(
-          child: _DropdownMenuItemContainer(
-            alignment: widget.alignment,
-            child: displayedHint,
+      items.add(
+        DefaultTextStyle(
+          style: _textStyle!.copyWith(color: Theme.of(context).hintColor),
+          child: IgnorePointer(
+            child: _DropdownMenuItemContainer(
+              alignment: widget.alignment,
+              child: displayedHint,
+            ),
           ),
         ),
-      ));
+      );
     }
 
-    final EdgeInsetsGeometry padding =
-        ButtonTheme.of(context).alignedDropdown ? _kAlignedButtonPadding : _kUnalignedButtonPadding;
+    final EdgeInsetsGeometry padding = ButtonTheme.of(context).alignedDropdown
+        ? _kAlignedButtonPadding
+        : _kUnalignedButtonPadding;
 
     // If value is null (then _selectedIndex is null) then we
     // display the hint or nothing at all.
@@ -1561,7 +1674,8 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
         //from the maximum width of menu items or the hint text (width of IndexedStack).
         //We need to add MenuHorizontalPadding so menu width adapts to max items width with padding properly
         padding: EdgeInsets.symmetric(
-          horizontal: _buttonStyle?.width == null && _dropdownStyle.width == null
+          horizontal:
+              _buttonStyle?.width == null && _dropdownStyle.width == null
               ? _getMenuHorizontalPadding()
               : 0.0,
         ),
@@ -1581,21 +1695,32 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
     }
 
     Widget result = DefaultTextStyle(
-      style: _enabled ? _textStyle! : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
-      child: widget.customButton ??
+      style: _enabled
+          ? _textStyle!
+          : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
+      child:
+          widget.customButton ??
           Container(
             decoration: _buttonStyle?.decoration?.copyWith(
-              boxShadow: _buttonStyle!.decoration!.boxShadow ??
+              boxShadow:
+                  _buttonStyle!.decoration!.boxShadow ??
                   kElevationToShadow[_buttonStyle!.elevation ?? 0],
             ),
-            padding: _buttonStyle?.padding ?? padding.resolve(Directionality.of(context)),
-            height: _buttonStyle?.height ?? (widget.isDense ? _denseButtonHeight : null),
+            padding:
+                _buttonStyle?.padding ??
+                padding.resolve(Directionality.of(context)),
+            height:
+                _buttonStyle?.height ??
+                (widget.isDense ? _denseButtonHeight : null),
             width: _buttonStyle?.width,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                if (widget.isExpanded) Expanded(child: innerItemsWidget) else innerItemsWidget,
+                if (widget.isExpanded)
+                  Expanded(child: innerItemsWidget)
+                else
+                  innerItemsWidget,
                 IconTheme(
                   data: IconThemeData(
                     color: _iconColor,
@@ -1606,8 +1731,8 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
                     builder: (BuildContext context, bool isOpen, _) {
                       return _iconStyle.openMenuIcon != null
                           ? isOpen
-                              ? _iconStyle.openMenuIcon!
-                              : _iconStyle.icon
+                                ? _iconStyle.openMenuIcon!
+                                : _iconStyle.icon
                           : _iconStyle.icon;
                     },
                   ),
@@ -1626,7 +1751,8 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
             left: 0.0,
             right: 0.0,
             bottom: bottom,
-            child: widget.underline ??
+            child:
+                widget.underline ??
                 Container(
                   height: 1.0,
                   decoration: const BoxDecoration(
@@ -1643,12 +1769,13 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBind
       );
     }
 
-    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
-      MaterialStateMouseCursor.clickable,
-      <MaterialState>{
-        if (!_enabled) MaterialState.disabled,
-      },
-    );
+    final MouseCursor effectiveMouseCursor =
+        MaterialStateProperty.resolveAs<MouseCursor>(
+          MaterialStateMouseCursor.clickable,
+          <MaterialState>{
+            if (!_enabled) MaterialState.disabled,
+          },
+        );
 
     if (widget._inputDecoration != null) {
       result = InputDecorator(
@@ -1735,88 +1862,101 @@ class DropdownButtonFormField2<T> extends FormField<T> {
     bool barrierDismissible = true,
     Color? barrierColor,
     String? barrierLabel,
-  })  : assert(
-          items == null ||
-              items.isEmpty ||
-              value == null ||
-              items.where((DropdownMenuItem<T> item) {
-                    return item.value == value;
-                  }).length ==
-                  1,
-          "There should be exactly one item with [DropdownButton]'s value: "
-          '$value. \n'
-          'Either zero or 2 or more [DropdownMenuItem]s were detected '
-          'with the same value',
-        ),
-        decoration = _getInputDecoration(decoration, buttonStyleData),
-        super(
-          initialValue: value,
-          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
-          builder: (FormFieldState<T> field) {
-            final _DropdownButtonFormFieldState<T> state =
-                field as _DropdownButtonFormFieldState<T>;
-            final InputDecoration decorationArg = _getInputDecoration(decoration, buttonStyleData);
-            final InputDecoration effectiveDecoration = decorationArg.applyDefaults(
-              Theme.of(field.context).inputDecorationTheme,
-            );
+  }) : assert(
+         items == null ||
+             items.isEmpty ||
+             value == null ||
+             items.where((DropdownMenuItem<T> item) {
+                   return item.value == value;
+                 }).length ==
+                 1,
+         "There should be exactly one item with [DropdownButton]'s value: "
+         '$value. \n'
+         'Either zero or 2 or more [DropdownMenuItem]s were detected '
+         'with the same value',
+       ),
+       decoration = _getInputDecoration(decoration, buttonStyleData),
+       super(
+         initialValue: value,
+         autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
+         builder: (FormFieldState<T> field) {
+           final _DropdownButtonFormFieldState<T> state =
+               field as _DropdownButtonFormFieldState<T>;
+           final InputDecoration decorationArg = _getInputDecoration(
+             decoration,
+             buttonStyleData,
+           );
+           final InputDecoration effectiveDecoration = decorationArg
+               .applyDefaults(
+                 Theme.of(field.context).inputDecorationTheme,
+               );
 
-            final bool showSelectedItem = items != null &&
-                items.where((DropdownMenuItem<T> item) => item.value == state.value).isNotEmpty;
-            bool isHintOrDisabledHintAvailable() {
-              final bool isDropdownDisabled = onChanged == null || (items == null || items.isEmpty);
-              if (isDropdownDisabled) {
-                return hint != null || disabledHint != null;
-              } else {
-                return hint != null;
-              }
-            }
+           final bool showSelectedItem =
+               items != null &&
+               items
+                   .where(
+                     (DropdownMenuItem<T> item) => item.value == state.value,
+                   )
+                   .isNotEmpty;
+           bool isHintOrDisabledHintAvailable() {
+             final bool isDropdownDisabled =
+                 onChanged == null || (items == null || items.isEmpty);
+             if (isDropdownDisabled) {
+               return hint != null || disabledHint != null;
+             } else {
+               return hint != null;
+             }
+           }
 
-            final bool isEmpty = !showSelectedItem && !isHintOrDisabledHintAvailable();
+           final bool isEmpty =
+               !showSelectedItem && !isHintOrDisabledHintAvailable();
 
-            // An unFocusable Focus widget so that this widget can detect if its
-            // descendants have focus or not.
-            return Focus(
-              canRequestFocus: false,
-              skipTraversal: true,
-              child: Builder(
-                builder: (BuildContext context) {
-                  return DropdownButtonHideUnderline(
-                    child: DropdownButton2<T>._formField(
-                      key: dropdownButtonKey,
-                      items: items,
-                      selectedItemBuilder: selectedItemBuilder,
-                      value: state.value,
-                      hint: hint,
-                      disabledHint: disabledHint,
-                      onChanged: onChanged == null ? null : state.didChange,
-                      onMenuStateChange: onMenuStateChange,
-                      style: style,
-                      isDense: isDense,
-                      isExpanded: isExpanded,
-                      focusNode: focusNode,
-                      autofocus: autofocus,
-                      enableFeedback: enableFeedback,
-                      alignment: alignment,
-                      buttonStyleData: buttonStyleData,
-                      iconStyleData: iconStyleData,
-                      dropdownStyleData: dropdownStyleData,
-                      menuItemStyleData: menuItemStyleData,
-                      dropdownSearchData: dropdownSearchData,
-                      customButton: customButton,
-                      openWithLongPress: openWithLongPress,
-                      barrierDismissible: barrierDismissible,
-                      barrierColor: barrierColor,
-                      barrierLabel: barrierLabel,
-                      inputDecoration: effectiveDecoration.copyWith(errorText: field.errorText),
-                      isEmpty: isEmpty,
-                      isFocused: Focus.of(context).hasFocus,
-                    ),
-                  );
-                },
-              ),
-            );
-          },
-        );
+           // An unFocusable Focus widget so that this widget can detect if its
+           // descendants have focus or not.
+           return Focus(
+             canRequestFocus: false,
+             skipTraversal: true,
+             child: Builder(
+               builder: (BuildContext context) {
+                 return DropdownButtonHideUnderline(
+                   child: DropdownButton2<T>._formField(
+                     key: dropdownButtonKey,
+                     items: items,
+                     selectedItemBuilder: selectedItemBuilder,
+                     value: state.value,
+                     hint: hint,
+                     disabledHint: disabledHint,
+                     onChanged: onChanged == null ? null : state.didChange,
+                     onMenuStateChange: onMenuStateChange,
+                     style: style,
+                     isDense: isDense,
+                     isExpanded: isExpanded,
+                     focusNode: focusNode,
+                     autofocus: autofocus,
+                     enableFeedback: enableFeedback,
+                     alignment: alignment,
+                     buttonStyleData: buttonStyleData,
+                     iconStyleData: iconStyleData,
+                     dropdownStyleData: dropdownStyleData,
+                     menuItemStyleData: menuItemStyleData,
+                     dropdownSearchData: dropdownSearchData,
+                     customButton: customButton,
+                     openWithLongPress: openWithLongPress,
+                     barrierDismissible: barrierDismissible,
+                     barrierColor: barrierColor,
+                     barrierLabel: barrierLabel,
+                     inputDecoration: effectiveDecoration.copyWith(
+                       errorText: field.errorText,
+                     ),
+                     isEmpty: isEmpty,
+                     isFocused: Focus.of(context).hasFocus,
+                   ),
+                 );
+               },
+             ),
+           );
+         },
+       );
 
   /// The key of DropdownButton2 child widget
   ///
@@ -1837,13 +1977,17 @@ class DropdownButtonFormField2<T> extends FormField<T> {
   final InputDecoration decoration;
 
   static InputDecoration _getInputDecoration(
-      InputDecoration? decoration, ButtonStyleData? buttonStyleData) {
+    InputDecoration? decoration,
+    ButtonStyleData? buttonStyleData,
+  ) {
     return decoration ??
         InputDecoration(
-          focusColor:
-              buttonStyleData?.overlayColor?.resolve(<MaterialState>{MaterialState.focused}),
-          hoverColor:
-              buttonStyleData?.overlayColor?.resolve(<MaterialState>{MaterialState.hovered}),
+          focusColor: buttonStyleData?.overlayColor?.resolve(<MaterialState>{
+            MaterialState.focused,
+          }),
+          hoverColor: buttonStyleData?.overlayColor?.resolve(<MaterialState>{
+            MaterialState.hovered,
+          }),
         );
   }
 

--- a/packages/werkbank/lib/src/_internal/src/package_copies/dropdown_button2/src/dropdown_button2_data.dart
+++ b/packages/werkbank/lib/src/_internal/src/package_copies/dropdown_button2/src/dropdown_button2_data.dart
@@ -252,10 +252,10 @@ class DropdownSearchData<T> {
     this.searchInnerWidgetHeight,
     this.searchMatchFn,
   }) : assert(
-          (searchInnerWidget == null) == (searchInnerWidgetHeight == null),
-          'searchInnerWidgetHeight should not be null when using searchInnerWidget\n'
-          'This is necessary to properly determine menu limits and scroll offset',
-        );
+         (searchInnerWidget == null) == (searchInnerWidgetHeight == null),
+         'searchInnerWidgetHeight should not be null when using searchInnerWidget\n'
+         'This is necessary to properly determine menu limits and scroll offset',
+       );
 
   /// The TextEditingController used for searchable dropdowns. If this is null,
   /// then it'll perform as a normal dropdown without searching feature.


### PR DESCRIPTION
Discussing personal formatting preferences is a tedious topic. Luckily it is mostly a topic of the past, because automatic formatters
exists. They may not always produce the _best_ result, but they do produce a good and uniform result and they save us from ever having to discuss formatting in pull requests again.

Run the default dart formatter in the CI to ensure new code is formatted correctly. Also re-check the formatting periodically to check if what is considered correct formatting has changed across dart versions.