### PR TITLE
ci: analyze: add job that runs the flutter analyze linter

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -1,0 +1,34 @@
+name: analyze
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '48 20 * * 4'
+
+jobs:
+  analyze:
+    strategy:
+      fail-fast: false
+      matrix:
+        directory:
+          - "apps/werkbank_werkbank"
+          - "example/example_werkbank"
+          - "packages/werkbank"
+
+    name: flutter analyze
+    runs-on: ubuntu-latest
+    container: ghcr.io/cirruslabs/flutter:stable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.directory }}
+        run: flutter pub get
+
+      - name: Analyze project source
+        working-directory: ${{ matrix.directory }}
+        run: flutter analyze

--- a/packages/werkbank/lib/src/addons/src/accessibility/src/_internal/semantics_inspector/semantics_inspector_overlay.dart
+++ b/packages/werkbank/lib/src/addons/src/accessibility/src/_internal/semantics_inspector/semantics_inspector_overlay.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:werkbank/src/addons/src/accessibility/src/_internal/semantics_inspector/ignore_pointer_with_semantics.dart';
 import 'package:werkbank/src/addons/src/accessibility/src/_internal/semantics_inspector/semantics_box_display.dart';
 import 'package:werkbank/src/addons/src/accessibility/src/_internal/semantics_inspector/semantics_inspector_controller.dart';

--- a/packages/werkbank/lib/src/addons/src/description/src/metadata/description.dart
+++ b/packages/werkbank/lib/src/addons/src/description/src/metadata/description.dart
@@ -1,4 +1,3 @@
-import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:werkbank/src/werkbank_internal.dart';
 
 class Descriptions extends UseCaseMetadataEntry<Descriptions> {

--- a/packages/werkbank/pubspec.yaml
+++ b/packages/werkbank/pubspec.yaml
@@ -42,8 +42,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-  assets:
-    - assets/components/background/
   fonts:
     - family: Werkbank Icons
       fonts:


### PR DESCRIPTION
A linter can help keep the code quality of a project high.

Set up a linting job per sub-project.