### PR TITLE
ci: build: add job to build the example and upload to GitHub pages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-example:
+    name: build example project
+    runs-on: ubuntu-latest
+    container: ghcr.io/cirruslabs/flutter:stable
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        working-directory: example/example_werkbank
+        run: flutter pub get
+
+      - name: Build web version of the example project
+        working-directory: example/example_werkbank
+        run: flutter build web --base-href /werkbank/
+
+      - name: Upload the generated artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: example/example_werkbank/build/web
+          retention-days: 90

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,20 @@ jobs:
   build-example:
     name: build example project
     runs-on: ubuntu-latest
-    container: ghcr.io/cirruslabs/flutter:stable
+    container: ghcr.io/cirruslabs/flutter:3.32.2
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check expected flutter version
+        shell: python3 {0}
+        run: |
+          import json
+
+          fvmrc_version = json.load(open(".fvmrc"))["flutter"]
+          sdk_version = open("/sdks/flutter/version").read().strip()
+
+          assert fvmrc_version == sdk_version
 
       - name: Install dependencies
         working-directory: example/example_werkbank

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,3 +38,23 @@ jobs:
         with:
           path: example/example_werkbank/build/web
           retention-days: 90
+
+  deploy-example:
+    name: deploy example project
+    runs-on: ubuntu-latest
+    needs: build-example
+
+    if: ${{ github.ref == 'refs/heads/main' && vars.DEPLOY_PAGES }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/werkbank/README.md
+++ b/packages/werkbank/README.md
@@ -6,7 +6,7 @@
 <p align="center">
   <a href="https://pub.dev/documentation/werkbank/latest/topics/Welcome-topic.html">Documentation</a> •
   <a href="https://pub.dev/documentation/werkbank/latest/topics/Get%20Started-topic.html">Get Started</a> •
-  <a href="https://example-werkbank-246cea10e259.playground.neusta-ms.de/">Web Demo</a>
+  <a href="https://neusta-mobile-solutions-gmbh.github.io/werkbank/">Web Demo</a>
 </p>
 
 > [!WARNING]
@@ -135,7 +135,7 @@ WidgetBuilder sliderUseCase(UseCaseComposer c) {
   - Learn everything about what Werkbank is and its technical details.
 - 🚀 [**Get Started**](https://pub.dev/documentation/werkbank/latest/topics/Get%20Started-topic.html)
   - If you already roughly know what Werkbank is, jump directly into setting up your Werkbank app.
-- 🌐 [**Example Werkbank Web Demo**](https://example-werkbank-246cea10e259.playground.neusta-ms.de/)
+- 🌐 [**Example Werkbank Web Demo**](https://neusta-mobile-solutions-gmbh.github.io/werkbank/)
   - Try out a Werkbank app in your browser.
 - 🛠️ [**Example Werkbank Code**](https://github.com/neusta-mobile-solutions-gmbh/werkbank/tree/main/example/example_werkbank)
   - Take a look at the code of the example web demo above and use it as a starting point for your own Werkbank app.


### PR DESCRIPTION
A build job can be a valuable resource for newcomers to a project to learn how to build the software.
Add a build job as an example of how to build a werkbank project and as an integration test to check if everything still compiles.
Also deploy the generated page to GitHub pages.

The deployment is conditional on two things:

  - `github.ref == 'refs/heads/main'`

    This ensures that deployment is only attempted for builds that run for the main branch, e.g. not pull requests or work on devel branches.

    See the [`github`][1] context documentation for reference.

  - `vars.DEPLOY_PAGES`

    A custom repository-wide [configuration variable][2].

    This ensures that the deployment is, by default, not attempted for forks (because the variable will not be set).

    The pages deployment requires a bit of configuration and would fail on a new fork, making the user experience less than ideal.

    Contributors that _do_ want to try the pages deployment can however set the variable in their fork and get working deployments that way. This makes it superior to e.g.: `github.repository == 'neusta-mobile-solutions-gmbh/werkbank'`.

[1]: https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#github-context
[2]: https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository

## Required setup

Add a `DEPLOY_PAGES` variable in the repository settings and set it to a true-ish value:

![new_variable](https://github.com/user-attachments/assets/0470b7aa-a631-46f5-b688-46d4e88fc897)
![variable_overview](https://github.com/user-attachments/assets/047cf304-b673-4dcf-937b-d60cc95a377e)

Set the GitHub Pages build and deployment source to "GitHub Actions":

![pages_source](https://github.com/user-attachments/assets/3a64b75f-3c53-4a4b-b4a9-00b490058551)

With this the build and deploy jobs should run successfully (when merged into main), as seen [here](https://github.com/hnez/werkbank/actions/runs/16045129461) and the resulting page should be deployed to GitHub pages, as seen here: [hnez.github.io/werkbank](https://hnez.github.io/werkbank/).