### PR TITLE
Add Werkbank System theme

### DIFF
--- a/packages/werkbank/CHANGELOG.md
+++ b/packages/werkbank/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added a `Werkbank System` theme, which will always match your system. It's also default now.
+
 # 0.16.0
 - Add `c.background.colorBuilder(...)` and `c.background.widgetBuilder(...)` to allow easier use of theme colors in backgrounds.
 - Fix that pointer could interact with use case while trying to change constraints.

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -28,7 +28,7 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
     with WidgetsBindingObserver {
   late WerkbankThemePersistentController _werkbankThemeController;
 
-  late bool systemIsInDarkMode;
+  late Brightness brightness;
 
   @override
   void initState() {
@@ -60,9 +60,8 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
   }
 
   void _updateDarkMode() {
-    systemIsInDarkMode =
-        SchedulerBinding.instance.platformDispatcher.platformBrightness ==
-        Brightness.dark;
+    brightness =
+        SchedulerBinding.instance.platformDispatcher.platformBrightness;
   }
 
   @override
@@ -90,7 +89,7 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
               ),
               'Werkbank System' || _ => WerkbankTheme(
                 colorScheme: WerkbankColorScheme.fromPalette(
-                  systemIsInDarkMode
+                  brightness == Brightness.dark
                       ? const WerkbankPalette.dark()
                       : const WerkbankPalette.light(),
                 ),

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -61,6 +61,14 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
     return ListenableBuilder(
       listenable: _werkbankThemeController,
       builder: (context, child) {
+        final darkColorScheme = WerkbankColorScheme.fromPalette(
+          const WerkbankPalette.dark(),
+        );
+
+        final lightColorScheme = WerkbankColorScheme.fromPalette(
+          const WerkbankPalette.light(),
+        );
+
         final themeName = _werkbankThemeController.themeName;
         return _InheritedWerkbankThemeState(
           themeName: themeName,
@@ -68,23 +76,17 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
             orderOption: WerkbankSettings.orderOptionOf(context),
             werkbankTheme: switch (themeName) {
               'Werkbank Dark' => WerkbankTheme(
-                colorScheme: WerkbankColorScheme.fromPalette(
-                  const WerkbankPalette.dark(),
-                ),
+                colorScheme: darkColorScheme,
                 textTheme: WerkbankTextTheme.standard(),
               ),
               'Werkbank Light' => WerkbankTheme(
-                colorScheme: WerkbankColorScheme.fromPalette(
-                  const WerkbankPalette.light(),
-                ),
+                colorScheme: lightColorScheme,
                 textTheme: WerkbankTextTheme.standard(),
               ),
               'Werkbank System' || _ => WerkbankTheme(
-                colorScheme: WerkbankColorScheme.fromPalette(
-                  brightness == Brightness.dark
-                      ? const WerkbankPalette.dark()
-                      : const WerkbankPalette.light(),
-                ),
+                colorScheme: brightness == Brightness.dark
+                    ? darkColorScheme
+                    : lightColorScheme,
                 textTheme: WerkbankTextTheme.standard(),
               ),
             },

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -23,16 +23,8 @@ class WerkbankThemeManager extends StatefulWidget {
   State<WerkbankThemeManager> createState() => _WerkbankThemeManagerState();
 }
 
-class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
-    with WidgetsBindingObserver {
+class _WerkbankThemeManagerState extends State<WerkbankThemeManager> {
   late WerkbankThemePersistentController _werkbankThemeController;
-
-  @override
-  void initState() {
-    super.initState();
-
-    WidgetsBinding.instance.addObserver(this);
-  }
 
   @override
   void didChangeDependencies() {
@@ -40,18 +32,6 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
     // TODO(cjaros): wrong layer used
     _werkbankThemeController = ApplicationOverlayLayerEntry.access
         .persistentControllerOf<WerkbankThemePersistentController>(context);
-  }
-
-  @override
-  void didChangePlatformBrightness() {
-    setState(() {});
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-
-    super.dispose();
   }
 
   @override

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -55,18 +55,19 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager> {
           child: WerkbankSettings(
             orderOption: WerkbankSettings.orderOptionOf(context),
             werkbankTheme: switch (themeName) {
-              'Werkbank Dark' => WerkbankTheme(
+              WerkbankThemeAddon.darkThemeName => WerkbankTheme(
                 colorScheme: darkColorScheme,
                 textTheme: WerkbankTextTheme.standard(),
               ),
-              'Werkbank Light' => WerkbankTheme(
+              WerkbankThemeAddon.lightThemeName => WerkbankTheme(
                 colorScheme: lightColorScheme,
                 textTheme: WerkbankTextTheme.standard(),
               ),
-              'Werkbank System' || _ => WerkbankTheme(
-                colorScheme: brightness == Brightness.dark
-                    ? darkColorScheme
-                    : lightColorScheme,
+              WerkbankThemeAddon.systemThemeName || _ => WerkbankTheme(
+                colorScheme: switch (brightness) {
+                  Brightness.dark => darkColorScheme,
+                  Brightness.light => lightColorScheme,
+                },
                 textTheme: WerkbankTextTheme.standard(),
               ),
             },
@@ -88,7 +89,7 @@ class WerkbankThemePersistentController extends PersistentController {
 
   @override
   void init(String? unsafeJson) {
-    themeName = unsafeJson ?? 'Werkbank System';
+    themeName = unsafeJson ?? WerkbankThemeAddon.systemThemeName;
   }
 
   late String themeName;

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -108,7 +108,7 @@ class WerkbankThemePersistentController extends PersistentController {
 
   @override
   void init(String? unsafeJson) {
-    themeName = unsafeJson ?? 'Werkbank Light';
+    themeName = unsafeJson ?? 'Werkbank System';
   }
 
   late String themeName;

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:werkbank/src/werkbank_internal.dart';
 
 class WerkbankThemeManager extends StatefulWidget {
@@ -28,15 +27,11 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
     with WidgetsBindingObserver {
   late WerkbankThemePersistentController _werkbankThemeController;
 
-  late Brightness brightness;
-
   @override
   void initState() {
     super.initState();
 
     WidgetsBinding.instance.addObserver(this);
-
-    _updateDarkMode();
   }
 
   @override
@@ -49,7 +44,7 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
 
   @override
   void didChangePlatformBrightness() {
-    setState(_updateDarkMode);
+    setState(() {});
   }
 
   @override
@@ -59,13 +54,10 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
     super.dispose();
   }
 
-  void _updateDarkMode() {
-    brightness =
-        SchedulerBinding.instance.platformDispatcher.platformBrightness;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final brightness = MediaQuery.platformBrightnessOf(context);
+
     return ListenableBuilder(
       listenable: _werkbankThemeController,
       builder: (context, child) {

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/_internal/werkbank_theme_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:werkbank/src/werkbank_internal.dart';
 
 class WerkbankThemeManager extends StatefulWidget {
@@ -23,8 +24,20 @@ class WerkbankThemeManager extends StatefulWidget {
   State<WerkbankThemeManager> createState() => _WerkbankThemeManagerState();
 }
 
-class _WerkbankThemeManagerState extends State<WerkbankThemeManager> {
+class _WerkbankThemeManagerState extends State<WerkbankThemeManager>
+    with WidgetsBindingObserver {
   late WerkbankThemePersistentController _werkbankThemeController;
+
+  late bool systemIsInDarkMode;
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addObserver(this);
+
+    _updateDarkMode();
+  }
 
   @override
   void didChangeDependencies() {
@@ -32,6 +45,24 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager> {
     // TODO(cjaros): wrong layer used
     _werkbankThemeController = ApplicationOverlayLayerEntry.access
         .persistentControllerOf<WerkbankThemePersistentController>(context);
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    setState(_updateDarkMode);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+
+    super.dispose();
+  }
+
+  void _updateDarkMode() {
+    systemIsInDarkMode =
+        SchedulerBinding.instance.platformDispatcher.platformBrightness ==
+        Brightness.dark;
   }
 
   @override
@@ -51,9 +82,17 @@ class _WerkbankThemeManagerState extends State<WerkbankThemeManager> {
                 ),
                 textTheme: WerkbankTextTheme.standard(),
               ),
-              'Werkbank Light' || _ => WerkbankTheme(
+              'Werkbank Light' => WerkbankTheme(
                 colorScheme: WerkbankColorScheme.fromPalette(
                   const WerkbankPalette.light(),
+                ),
+                textTheme: WerkbankTextTheme.standard(),
+              ),
+              'Werkbank System' || _ => WerkbankTheme(
+                colorScheme: WerkbankColorScheme.fromPalette(
+                  systemIsInDarkMode
+                      ? const WerkbankPalette.dark()
+                      : const WerkbankPalette.light(),
                 ),
                 textTheme: WerkbankTextTheme.standard(),
               ),

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/werkbank_theme_addon.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/werkbank_theme_addon.dart
@@ -10,10 +10,14 @@ class WerkbankThemeAddon extends Addon {
 
   static const addonId = 'werkbank_theme';
 
+  static const lightThemeName = 'Werkbank Light';
+  static const darkThemeName = 'Werkbank Dark';
+  static const systemThemeName = 'Werkbank System';
+
   static const List<String> _themeNames = [
-    'Werkbank Light',
-    'Werkbank Dark',
-    'Werkbank System',
+    lightThemeName,
+    darkThemeName,
+    systemThemeName,
   ];
 
   @override

--- a/packages/werkbank/lib/src/addons/src/werkbank_theme/src/werkbank_theme_addon.dart
+++ b/packages/werkbank/lib/src/addons/src/werkbank_theme/src/werkbank_theme_addon.dart
@@ -13,6 +13,7 @@ class WerkbankThemeAddon extends Addon {
   static const List<String> _themeNames = [
     'Werkbank Light',
     'Werkbank Dark',
+    'Werkbank System',
   ];
 
   @override


### PR DESCRIPTION
Hi there!

I though it would be nice if Werkbank could follow the system theme, so you don't get blinded when you open it at night:

https://github.com/user-attachments/assets/69556be4-69e9-41b3-a48a-0ca17932e5a0

The default is still the light theme. What do you think?